### PR TITLE
feat(auth): Story 2.1.1 — public read for /reports and /topics (closes #12)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,22 @@
 # Developer Log
 
+## 2026-03-01 - Story 2.1.1: Veřejné čtení bez přihlášení (Issue #12) — Oompa Loompa
+
+### Changes
+
+- **`src/utils/supabase/proxy.ts`**: Added `/reports` and `/topics` to the public-routes allowlist so unauthenticated users are no longer redirected to `/login` when accessing these pages.
+- **`src/app/topics/TopicsClient.tsx`**: Vote buttons (ThumbsUp / ThumbsDown) are now hidden for unauthenticated users. Read-only vote counts are shown alongside a "Přihlaste se pro hlasování" login link instead.
+- **`src/utils/supabase/proxy.test.ts`** *(new)*: 13 tests covering public routes (`/`, `/login`, `/auth/*`, `/reports`, `/topics`) pass through without redirect, protected routes (`/dashboard`, `/profile`, `/settings`) redirect unauthenticated users to `/login`, and all routes pass through for authenticated users.
+- **`src/app/topics/TopicsClient.test.tsx`**: Updated two tests to match the new UX — replaced the "redirects on vote click" test with "shows login link for votes when logged out" and tightened the login-message assertion.
+- **`PLAN.md`**: Added and checked off Story 2.1.1 under new Epic 2.1.
+
+### Verification
+
+- Ran `npm test`: PASS (88 tests, +13 from 75).
+- Ran `npm run lint`: PASS (0 errors, 0 warnings).
+
+---
+
 ## 2026-03-01 - Created PR #20 for Issue #10 (Oompa Loompa)
 
 Story 1.4.2: Základní Pulse Dashboard — PR #20 created against `main`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -67,6 +67,16 @@ Tento dokument slouží jako detailní architektonický plán pro vývojový tý
 
 ## Phase 2: "The Analytics Factory" (Pro Úředníky a Média)
 
+### Epic 2.1: Přístupnost a veřejné čtení
+
+- [x] **Story 2.1.1: Veřejné čtení bez přihlášení (Issue #12)**
+  - [x] Upravit middleware (`src/utils/supabase/proxy.ts`), aby `/reports` a `/topics` (GET) byly veřejně přístupné.
+  - [x] Ověřit, že RLS politiky v Supabase povolují SELECT bez autentizace (již bylo nastaveno).
+  - [x] Na stránce `/topics` skrýt hlasovací tlačítka pro nepřihlášené — zobrazit read-only počty hlasů a odkaz na přihlášení.
+  - [x] Napsat testy pro middleware (veřejné vs. chráněné routes) v `src/utils/supabase/proxy.test.ts`.
+
+
+
 _(Detailní plánování bude následovat po dokončení Fáze 1)_
 
 ## Phase 3: "The Omnipresent Pulse" (Rozšíření)

--- a/src/app/topics/TopicsClient.test.tsx
+++ b/src/app/topics/TopicsClient.test.tsx
@@ -64,7 +64,7 @@ describe('TopicsClient', () => {
 
   test('shows login message if not logged in', () => {
     render(<TopicsClient initialTopics={mockTopics} user={null} />);
-    expect(screen.getByText(/přihlaste/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pro přidání tématu se/i)).toBeInTheDocument();
   });
 
   test('shows creation button if logged in', () => {
@@ -83,14 +83,13 @@ describe('TopicsClient', () => {
     });
   });
 
-  test('redirects to login if voting (logged out)', async () => {
+  test('shows login link for votes when logged out', () => {
     render(<TopicsClient initialTopics={mockTopics} user={null} />);
-    const upButton = screen.getAllByTestId('thumb-up')[0];
-    fireEvent.click(upButton);
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/login');
-    });
+    const loginLink = screen.getByText('Přihlaste se pro hlasování');
+    expect(loginLink).toBeInTheDocument();
+    expect(loginLink.closest('a')).toHaveAttribute('href', '/login');
+    // Vote buttons must not be rendered as interactive buttons
+    expect(screen.queryByRole('button', { name: /up/i })).not.toBeInTheDocument();
   });
 
   test('toggles comments section', () => {

--- a/src/app/topics/TopicsClient.tsx
+++ b/src/app/topics/TopicsClient.tsx
@@ -244,22 +244,32 @@ export default function TopicsClient({
 
                 <div className="flex items-center gap-6 border-t border-zinc-100 pt-4 dark:border-zinc-800">
                   <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => handleVote(topic.id, 'up')}
-                      disabled={isPending}
-                      className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'up' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
-                    >
-                      <ThumbsUp className={`h-4 w-4 ${userVote === 'up' ? 'fill-current' : ''}`} />
-                      <span className="text-sm font-bold">{upVotes}</span>
-                    </button>
-                    <button
-                      onClick={() => handleVote(topic.id, 'down')}
-                      disabled={isPending}
-                      className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'down' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
-                    >
-                      <ThumbsDown className={`h-4 w-4 ${userVote === 'down' ? 'fill-current' : ''}`} />
-                      <span className="text-sm font-bold">{downVotes}</span>
-                    </button>
+                    {user ? (
+                      <>
+                        <button
+                          onClick={() => handleVote(topic.id, 'up')}
+                          disabled={isPending}
+                          className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'up' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
+                        >
+                          <ThumbsUp className={`h-4 w-4 ${userVote === 'up' ? 'fill-current' : ''}`} />
+                          <span className="text-sm font-bold">{upVotes}</span>
+                        </button>
+                        <button
+                          onClick={() => handleVote(topic.id, 'down')}
+                          disabled={isPending}
+                          className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'down' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
+                        >
+                          <ThumbsDown className={`h-4 w-4 ${userVote === 'down' ? 'fill-current' : ''}`} />
+                          <span className="text-sm font-bold">{downVotes}</span>
+                        </button>
+                      </>
+                    ) : (
+                      <span className="flex items-center gap-3 text-sm text-zinc-400">
+                        <span className="flex items-center gap-1"><ThumbsUp className="h-4 w-4" />{upVotes}</span>
+                        <span className="flex items-center gap-1"><ThumbsDown className="h-4 w-4" />{downVotes}</span>
+                        <a href="/login" className="text-blue-600 hover:underline text-xs">Přihlaste se pro hlasování</a>
+                      </span>
+                    )}
                   </div>
 
                   <button

--- a/src/utils/supabase/proxy.test.ts
+++ b/src/utils/supabase/proxy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateSession } from './proxy'
+import { NextRequest } from 'next/server'
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn(),
+    },
+  })),
+}))
+
+import { createServerClient } from '@supabase/ssr'
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${pathname}`)
+}
+
+function mockUser(user: object | null) {
+  vi.mocked(createServerClient).mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user } }),
+    },
+  } as never)
+}
+
+describe('updateSession middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('unauthenticated user — public routes (no redirect)', () => {
+    beforeEach(() => mockUser(null))
+
+    it('allows GET /', async () => {
+      const res = await updateSession(makeRequest('/'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /login', async () => {
+      const res = await updateSession(makeRequest('/login'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /auth/callback', async () => {
+      const res = await updateSession(makeRequest('/auth/callback'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /reports', async () => {
+      const res = await updateSession(makeRequest('/reports'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /reports/123', async () => {
+      const res = await updateSession(makeRequest('/reports/123'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /topics', async () => {
+      const res = await updateSession(makeRequest('/topics'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('allows GET /topics/456', async () => {
+      const res = await updateSession(makeRequest('/topics/456'))
+      expect(res.status).not.toBe(307)
+      expect(res.headers.get('location')).toBeNull()
+    })
+  })
+
+  describe('unauthenticated user — protected routes (redirect to /login)', () => {
+    beforeEach(() => mockUser(null))
+
+    it('redirects GET /dashboard to /login', async () => {
+      const res = await updateSession(makeRequest('/dashboard'))
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login')
+    })
+
+    it('redirects GET /profile to /login', async () => {
+      const res = await updateSession(makeRequest('/profile'))
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login')
+    })
+
+    it('redirects GET /settings to /login', async () => {
+      const res = await updateSession(makeRequest('/settings'))
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login')
+    })
+  })
+
+  describe('authenticated user — all routes pass through', () => {
+    beforeEach(() => mockUser({ id: 'user-1', email: 'user@example.com' }))
+
+    it('passes through GET /dashboard', async () => {
+      const res = await updateSession(makeRequest('/dashboard'))
+      expect(res.status).not.toBe(307)
+    })
+
+    it('passes through GET /reports', async () => {
+      const res = await updateSession(makeRequest('/reports'))
+      expect(res.status).not.toBe(307)
+    })
+
+    it('passes through GET /topics', async () => {
+      const res = await updateSession(makeRequest('/topics'))
+      expect(res.status).not.toBe(307)
+    })
+  })
+})

--- a/src/utils/supabase/proxy.ts
+++ b/src/utils/supabase/proxy.ts
@@ -39,6 +39,8 @@ export async function updateSession(request: NextRequest) {
     !user &&
     !request.nextUrl.pathname.startsWith('/login') &&
     !request.nextUrl.pathname.startsWith('/auth') &&
+    !request.nextUrl.pathname.startsWith('/reports') &&
+    !request.nextUrl.pathname.startsWith('/topics') &&
     request.nextUrl.pathname !== '/'
   ) {
     // no user, potentially respond by redirecting the user to the login page


### PR DESCRIPTION
## Summary

- Updated `src/utils/supabase/proxy.ts` to allow unauthenticated GET access to `/reports` and `/topics` — no more login redirect for read-only browsing
- Updated `src/app/topics/TopicsClient.tsx` to hide vote buttons for logged-out users; read-only vote counts + "Přihlaste se pro hlasování" link shown instead
- Added `src/utils/supabase/proxy.test.ts` with 13 new middleware tests covering public vs protected routes

## Test plan

- [x] `npm test` — 88 tests pass (+13 new)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] Unauthenticated access to `/reports` and `/topics` passes through middleware without redirect
- [x] `/dashboard`, `/profile`, `/settings` still redirect unauthenticated users to `/login`
- [x] Vote buttons hidden for logged-out users on `/topics`; login link shown instead
- [x] All existing optimistic-UI and voting tests updated and passing

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)