### PR TITLE
chore: remove @vercel/analytics

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,17 @@
 # Developer Log
 
+## 2026-03-02 - chore: remove @vercel/analytics (Issue #34) — Oompa Loompa
+
+### Changes
+
+- **`src/app/layout.tsx`**: Removed `import { Analytics } from '@vercel/analytics/next'` and `<Analytics />` component from `RootLayout`.
+- **`package.json` / `package-lock.json`**: Ran `npm uninstall @vercel/analytics` — package removed entirely.
+
+### Verification
+
+- `npm run build` — compiled successfully, no errors.
+- No tests were affected (2 pre-existing failures in `page.test.tsx` / `page_auth.test.tsx` are unrelated — they test for a `<button>` that doesn't exist in the current page).
+
 ## 2026-03-02 - perf: consolidate double reports fetch in dashboard page (Issue #22) — Oompa Loompa
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.98.0",
-        "@vercel/analytics": "^1.6.1",
         "lucide-react": "^0.575.0",
         "maplibre-gl": "^5.19.0",
         "next": "16.1.6",
@@ -3630,43 +3629,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
-      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.98.0",
-    "@vercel/analytics": "^1.6.1",
     "lucide-react": "^0.575.0",
     "maplibre-gl": "^5.19.0",
     "next": "16.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import { Analytics } from '@vercel/analytics/next';
 import './globals.css';
 
 const geistSans = Geist({
@@ -29,7 +28,6 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
-        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Removes `@vercel/analytics` package which caused `Module not found` errors on self-hosted deployments
- Deleted `import { Analytics }` and `<Analytics />` from `src/app/layout.tsx`
- Uninstalled package via `npm uninstall @vercel/analytics`

Closes #34

## Test plan

- [x] `npm run build` — compiles without errors
- [x] No regressions in test suite (204/206 tests pass; 2 pre-existing failures in `page.test.tsx`/`page_auth.test.tsx` are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)