### PR TITLE
feat: civic color system + shared Header (closes #37)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,34 @@
 # Developer Log
 
+## 2026-03-02 - feat: civic color system + shared Header (Issue #37) — Oompa Loompa
+
+### Changes
+
+- **`src/app/globals.css`**: Civic-platform CSS variables — `--primary` blue-600/blue-500, `--surface` slate-50/zinc-900, `--border` slate-200/zinc-800, `--background` white/zinc-950. Exposed via `@theme inline`.
+- **`src/components/HeaderClient.tsx`** *(new)*: Client component — logo "Náš stát", desktop nav (Mapa / Témata / Dashboard) with active state via `usePathname`, auth buttons (Přihlásit / Odhlásit), mobile hamburger menu with `aria-expanded`.
+- **`src/components/Header.tsx`** *(new)*: Async server component — reads Supabase user session, renders `HeaderClient`.
+- **`src/app/layout.tsx`**: Added `<Header />` to root layout so it appears on every page.
+- **`src/app/page.tsx`**: Removed duplicate auth header (now in global Header); simplified hero layout using new slate/blue color tokens; "Nahlásit podnět" href changed from `/reports?new=1` → `/reports`.
+- **`src/app/reports/page.tsx`**: Removed local `<header>`; outer div height changed from `h-screen` → `h-[calc(100vh-4rem)]` to account for 64px global Header.
+- **`src/app/topics/page.tsx`**: Removed local `<header>`; outer div uses `min-h-[calc(100vh-4rem)]`.
+- **`src/app/dashboard/page.tsx`**: Removed sticky local header; page title moved inline below `<main>`.
+- **`src/app/admin/page.tsx`**: Replaced full-height local header with a compact 48px title bar.
+
+### Tests
+
+- **`src/components/Header.test.tsx`** *(new — 9 tests)*: logo link, nav links, login/logout display, hamburger toggle, mobile nav visibility, active nav class.
+- **`src/app/page.test.tsx`**: Removed stale "shows login button" test (now covered by Header tests).
+- **`src/app/page_auth.test.tsx`**: Removed stale email/logout tests; updated report link assertion (`/reports` instead of `/reports?new=1`).
+- **`src/app/reports/page.test.tsx`**: Removed assertions for removed header element.
+- **`src/app/topics/page.test.tsx`**: Removed assertions for removed header element.
+
+### Verification
+
+- `npm run test` — 222/222 passed.
+- `npm run build` — compiled successfully, 10 routes.
+
+---
+
 ## 2026-03-02 - fix: Zod refine + floating button tests (Issue #36, round 2) — Oompa Loompa
 
 ### Changes

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/utils/supabase/server';
 import AdminClient from './AdminClient';
@@ -51,24 +49,15 @@ export default async function AdminPage() {
   const comments = commentsData ?? [];
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
-      {/* Header */}
-      <header className="z-10 flex h-16 items-center border-b border-zinc-200 bg-white px-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <Link
-          href="/"
-          className="mr-4 flex items-center gap-1 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Zpět
-        </Link>
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+    <div className="min-h-[calc(100vh-4rem)] bg-zinc-50 dark:bg-black">
+      <div className="flex h-12 items-center gap-3 border-b border-zinc-200 bg-white px-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <h1 className="text-lg font-bold text-zinc-900 dark:text-zinc-100">
           Admin panel
         </h1>
-        <span className="ml-3 rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+        <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
           {reports.length} hlášení · {topics.length} témat · {comments.length} komentářů
         </span>
-      </header>
-
+      </div>
       <main>
         <AdminClient reports={reports} topics={topics} comments={comments} />
       </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowLeft, LayoutDashboard, Star, MapPin, MessageSquare, TrendingUp, Info } from 'lucide-react';
+import { LayoutDashboard, Star, MapPin, MessageSquare, TrendingUp, Info } from 'lucide-react';
 import { createClient } from '@/utils/supabase/server';
 import Map, { Report } from '@/components/Map';
 import { STATUS_LABELS, STATUS_COLORS } from '@/lib/reportStatus';
@@ -60,24 +60,13 @@ export default async function DashboardPage() {
     });
 
   return (
-    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
-      {/* Header */}
-      <header className="sticky top-0 z-10 flex h-16 items-center border-b border-zinc-200 bg-white px-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <Link
-          href="/"
-          className="mr-4 flex items-center gap-1 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Zpět
-        </Link>
-        <LayoutDashboard className="mr-2 h-5 w-5 text-blue-600" />
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
-          Pulse Dashboard
-        </h1>
-      </header>
-
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col bg-zinc-50 dark:bg-black">
       {/* Main content */}
       <main className="flex-1 overflow-y-auto px-6 py-8">
+        <div className="mx-auto mb-6 flex max-w-5xl items-center gap-2">
+          <LayoutDashboard className="h-5 w-5 text-blue-600" />
+          <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">Pulse Dashboard</h1>
+        </div>
         <div className="mx-auto max-w-5xl space-y-8">
           
           {/* Stats Grid */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,36 @@
 @import 'tailwindcss';
 
+/* Civic-platform color system
+   Light: bg white, surface slate-50, border slate-200, primary blue-600
+   Dark:  bg zinc-950, surface zinc-900, border zinc-800, primary blue-500
+*/
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #0f172a;
+  --surface: #f8fafc;
+  --border: #e2e8f0;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-border: var(--border);
+  --color-primary: var(--primary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #09090b;
+    --foreground: #f4f4f5;
+    --surface: #18181b;
+    --border: #27272a;
+    --primary: #3b82f6;
+    --primary-hover: #60a5fa;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
+import Header from '@/components/Header';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -16,22 +16,11 @@ vi.mock('next/headers', () => ({
   cookies: vi.fn(),
 }));
 
-vi.mock('./login/actions', () => ({
-  logout: vi.fn(),
-}));
-
 test('renders Home page with welcome message', async () => {
   const ResolvedPage = await Page();
   render(ResolvedPage);
   const element = screen.getByText(/Vítejte v aplikaci Náš stát/i);
   expect(element).toBeInTheDocument();
-});
-
-test('shows login button when user is not logged in', async () => {
-  const ResolvedPage = await Page();
-  render(ResolvedPage);
-  const loginLink = screen.getByRole('link', { name: /přihlásit se/i });
-  expect(loginLink).toHaveAttribute('href', '/login');
 });
 
 test('shows report link pointing to /login when not logged in', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,4 @@
-import Image from 'next/image';
 import { createClient } from '@/utils/supabase/server';
-import { logout } from './login/actions';
 
 export default async function Home() {
   const supabase = await createClient();
@@ -10,40 +8,10 @@ export default async function Home() {
   } = await supabase.auth.getUser();
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <div className="flex w-full items-center justify-between">
-          <Image
-            className="dark:invert"
-            src="/next.svg"
-            alt="Next.js logo"
-            width={100}
-            height={20}
-            priority
-          />
-          {user ? (
-            <div className="flex items-center gap-4">
-              <span className="text-sm text-zinc-600 dark:text-zinc-400">{user.email}</span>
-              <form action={logout}>
-                <button
-                  type="submit"
-                  className="rounded-md bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700"
-                >
-                  Odhlásit se
-                </button>
-              </form>
-            </div>
-          ) : (
-            <a
-              href="/login"
-              className="rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700"
-            >
-              Přihlásit se
-            </a>
-          )}
-        </div>
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-slate-50 dark:bg-zinc-950">
+      <main className="flex w-full max-w-3xl flex-col items-center gap-12 px-8 py-24 sm:items-start">
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
+          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-zinc-900 dark:text-zinc-50">
             Vítejte v aplikaci Náš stát
           </h1>
           <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
@@ -52,25 +20,25 @@ export default async function Home() {
         </div>
         <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
           <a
-            href={user ? '/reports?new=1' : '/login'}
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[200px]"
+            href={user ? '/reports' : '/login'}
+            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-blue-600 px-5 text-white transition-colors hover:bg-blue-700 md:w-[200px]"
           >
             Nahlásit podnět
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[200px]"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-slate-200 px-5 transition-colors hover:bg-slate-100 dark:border-zinc-800 dark:hover:bg-zinc-900 md:w-[200px]"
             href="/reports"
           >
             Zobrazit mapu
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[200px]"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-slate-200 px-5 transition-colors hover:bg-slate-100 dark:border-zinc-800 dark:hover:bg-zinc-900 md:w-[200px]"
             href="/topics"
           >
             Tématický feed
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[200px]"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-slate-200 px-5 transition-colors hover:bg-slate-100 dark:border-zinc-800 dark:hover:bg-zinc-900 md:w-[200px]"
             href="/dashboard"
           >
             Dashboard

--- a/src/app/page_auth.test.tsx
+++ b/src/app/page_auth.test.tsx
@@ -19,25 +19,9 @@ vi.mock('next/headers', () => ({
   cookies: vi.fn(),
 }));
 
-vi.mock('./login/actions', () => ({
-  logout: vi.fn(),
-}));
-
-test('shows user email when logged in', async () => {
-  const ResolvedPage = await Page();
-  render(ResolvedPage);
-  expect(screen.getByText(/test@example.com/i)).toBeInTheDocument();
-});
-
-test('shows logout button when logged in', async () => {
-  const ResolvedPage = await Page();
-  render(ResolvedPage);
-  expect(screen.getByRole('button', { name: /odhlásit se/i })).toBeInTheDocument();
-});
-
-test('shows report link pointing to /reports?new=1 when logged in', async () => {
+test('shows report link pointing to /reports when logged in', async () => {
   const ResolvedPage = await Page();
   render(ResolvedPage);
   const reportLink = screen.getByRole('link', { name: /nahlásit podnět/i });
-  expect(reportLink).toHaveAttribute('href', '/reports?new=1');
+  expect(reportLink).toHaveAttribute('href', '/reports');
 });

--- a/src/app/reports/page.test.tsx
+++ b/src/app/reports/page.test.tsx
@@ -54,10 +54,6 @@ vi.mock('./ReportsClient', () => ({
   ),
 }));
 
-// Mock Lucide-react
-vi.mock('lucide-react', () => ({
-  ArrowLeft: () => <div data-testid="arrow-left-icon">ArrowLeft</div>,
-}));
 
 describe('ReportsPage', () => {
   test('renders page header and reports client with default params', async () => {
@@ -90,7 +86,6 @@ describe('ReportsPage', () => {
     });
     render(PageComponent);
 
-    expect(screen.getByText(/Hlášení podnětů/i)).toBeInTheDocument();
     expect(screen.getByTestId('mocked-reports-client')).toBeInTheDocument();
     expect(screen.getByText(/Mocked ReportsClient \(1 reports\)/i)).toBeInTheDocument();
     expect(screen.getByTestId('first-report-title')).toHaveTextContent('Díra v silnici');
@@ -99,8 +94,6 @@ describe('ReportsPage', () => {
     expect(screen.getByTestId('current-status')).toHaveTextContent('');
     expect(screen.getByTestId('current-category')).toHaveTextContent('');
 
-    const backButton = screen.getByRole('link', { name: /zpět/i });
-    expect(backButton).toHaveAttribute('href', '/');
   });
 
   test('passes status and category filters from searchParams', async () => {

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
 import ReportsClient from './ReportsClient';
 import { createClient } from '@/utils/supabase/server';
 import { Report } from '@/components/Map';
@@ -71,21 +69,7 @@ export default async function ReportsPage({
   const totalPages = Math.max(1, Math.ceil((count ?? 0) / PAGE_SIZE));
 
   return (
-    <div className="flex h-screen flex-col bg-zinc-50 dark:bg-black">
-      {/* Header */}
-      <header className="z-10 flex h-16 items-center border-b border-zinc-200 bg-white px-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <Link
-          href="/"
-          className="mr-4 flex items-center gap-1 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Zpět
-        </Link>
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
-          Hlášení podnětů
-        </h1>
-      </header>
-
+    <div className="flex h-[calc(100vh-4rem)] flex-col bg-zinc-50 dark:bg-black">
       {/* Main content - Map & Client logic */}
       <main className="relative flex-1">
         <ReportsClient

--- a/src/app/topics/page.test.tsx
+++ b/src/app/topics/page.test.tsx
@@ -28,12 +28,7 @@ vi.mock('./TopicsClient', () => ({
   ),
 }));
 
-// Mock Lucide-react
-vi.mock('lucide-react', () => ({
-  ArrowLeft: () => <div data-testid="arrow-left-icon">ArrowLeft</div>,
-}));
-
-test('renders Topics page with header and topics client', async () => {
+test('renders Topics page with topics client', async () => {
   const { createClient } = await import('@/utils/supabase/server');
   vi.mocked(createClient).mockResolvedValue({
     auth: {
@@ -62,14 +57,8 @@ test('renders Topics page with header and topics client', async () => {
   const PageComponent = await Page();
   render(PageComponent);
 
-  const header = screen.getByText(/Tématický Feed/i);
-  expect(header).toBeInTheDocument();
-
   const topicsClient = screen.getByTestId('mocked-topics-client');
   expect(topicsClient).toBeInTheDocument();
   expect(screen.getByText(/Mocked TopicsClient \(1 topics\)/i)).toBeInTheDocument();
   expect(screen.getByTestId('first-topic-title')).toHaveTextContent('Nová reforma školství');
-
-  const backButton = screen.getByRole('link', { name: /zpět/i });
-  expect(backButton).toHaveAttribute('href', '/');
 });

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
 import { createClient } from '@/utils/supabase/server';
 import TopicsClient from './TopicsClient';
 
@@ -41,22 +39,7 @@ export default async function TopicsPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
-      {/* Header */}
-      <header className="sticky top-0 z-10 flex h-16 items-center border-b border-zinc-200 bg-white px-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <Link
-          href="/"
-          className="mr-4 flex items-center gap-1 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Zpět
-        </Link>
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
-          Tématický Feed
-        </h1>
-      </header>
-
-      {/* Main content */}
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col bg-zinc-50 dark:bg-black">
       <main className="flex-1 overflow-y-auto px-6 py-8">
         <div className="mx-auto max-w-3xl">
           <TopicsClient initialTopics={topicsData || []} user={user} />

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi, describe } from 'vitest';
+import HeaderClient from './HeaderClient';
+import type { User } from '@supabase/supabase-js';
+
+// Mock Next.js navigation
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+}));
+
+// Mock Next.js Link
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock logout server action
+vi.mock('@/app/login/actions', () => ({
+  logout: vi.fn(),
+}));
+
+const mockUser: User = {
+  id: 'user-1',
+  email: 'test@example.com',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  created_at: '',
+};
+
+describe('HeaderClient', () => {
+  test('renders logo link "Náš stát"', () => {
+    render(<HeaderClient user={null} />);
+    const logo = screen.getByRole('link', { name: /náš stát/i });
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute('href', '/');
+  });
+
+  test('renders all desktop nav links', () => {
+    render(<HeaderClient user={null} />);
+    expect(screen.getByRole('link', { name: 'Mapa' })).toHaveAttribute('href', '/reports');
+    expect(screen.getByRole('link', { name: 'Témata' })).toHaveAttribute('href', '/topics');
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard');
+  });
+
+  test('shows "Přihlásit se" when user is null', () => {
+    render(<HeaderClient user={null} />);
+    // Desktop shows at least one login link
+    const loginLinks = screen.getAllByRole('link', { name: /přihlásit se/i });
+    expect(loginLinks.length).toBeGreaterThan(0);
+    expect(loginLinks[0]).toHaveAttribute('href', '/login');
+  });
+
+  test('shows user email and logout button when user is logged in', () => {
+    render(<HeaderClient user={mockUser} />);
+    expect(screen.getAllByText(/test@example.com/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /odhlásit se/i })).toBeInTheDocument();
+  });
+
+  test('does not show login link when user is logged in', () => {
+    render(<HeaderClient user={mockUser} />);
+    expect(screen.queryByRole('link', { name: /přihlásit se/i })).not.toBeInTheDocument();
+  });
+
+  test('hamburger button is rendered', () => {
+    render(<HeaderClient user={null} />);
+    expect(screen.getByRole('button', { name: /otevřít menu/i })).toBeInTheDocument();
+  });
+
+  test('clicking hamburger opens mobile nav', () => {
+    render(<HeaderClient user={null} />);
+    const hamburger = screen.getByRole('button', { name: /otevřít menu/i });
+    // Mobile nav not yet visible
+    expect(screen.queryByRole('navigation', { name: /mobilní navigace/i })).not.toBeInTheDocument();
+    fireEvent.click(hamburger);
+    // Mobile nav appears; close button shown
+    expect(screen.getByRole('navigation', { name: /mobilní navigace/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /zavřít menu/i })).toBeInTheDocument();
+  });
+
+  test('clicking hamburger again closes mobile nav', () => {
+    render(<HeaderClient user={null} />);
+    const hamburger = screen.getByRole('button', { name: /otevřít menu/i });
+    fireEvent.click(hamburger);
+    const closeBtn = screen.getByRole('button', { name: /zavřít menu/i });
+    fireEvent.click(closeBtn);
+    expect(screen.queryByRole('button', { name: /zavřít menu/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: /mobilní navigace/i })).not.toBeInTheDocument();
+  });
+
+  test('active nav link gets active class when pathname matches', async () => {
+    const { usePathname } = await import('next/navigation');
+    (usePathname as ReturnType<typeof vi.fn>).mockReturnValue('/reports');
+
+    render(<HeaderClient user={null} />);
+    const mapaLinks = screen.getAllByRole('link', { name: 'Mapa' });
+    expect(mapaLinks[0].className).toContain('text-blue-600');
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import { createClient } from '@/utils/supabase/server';
+import HeaderClient from './HeaderClient';
+
+export default async function Header() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return <HeaderClient user={user} />;
+}

--- a/src/components/HeaderClient.tsx
+++ b/src/components/HeaderClient.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+import { logout } from '@/app/login/actions';
+import type { User } from '@supabase/supabase-js';
+
+const NAV_LINKS = [
+  { href: '/reports', label: 'Mapa' },
+  { href: '/topics', label: 'Témata' },
+  { href: '/dashboard', label: 'Dashboard' },
+];
+
+export default function HeaderClient({ user }: { user: User | null }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
+        {/* Logo */}
+        <Link
+          href="/"
+          className="text-lg font-bold text-blue-600 dark:text-blue-500"
+        >
+          Náš stát
+        </Link>
+
+        {/* Desktop nav */}
+        <nav
+          className="hidden items-center gap-6 md:flex"
+          aria-label="Hlavní navigace"
+        >
+          {NAV_LINKS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`text-sm font-medium transition-colors ${
+                pathname.startsWith(href)
+                  ? 'text-blue-600 dark:text-blue-500'
+                  : 'text-slate-600 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-zinc-100'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </nav>
+
+        {/* Desktop auth */}
+        <div className="hidden items-center gap-3 md:flex">
+          {user ? (
+            <>
+              <span className="max-w-[200px] truncate text-sm text-slate-600 dark:text-zinc-400">
+                {user.email}
+              </span>
+              <form action={logout}>
+                <button
+                  type="submit"
+                  className="rounded-md bg-slate-100 px-3 py-1 text-xs font-medium text-slate-900 hover:bg-slate-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700"
+                >
+                  Odhlásit se
+                </button>
+              </form>
+            </>
+          ) : (
+            <Link
+              href="/login"
+              className="rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              Přihlásit se
+            </Link>
+          )}
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          className="md:hidden"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? 'Zavřít menu' : 'Otevřít menu'}
+          aria-expanded={open}
+          aria-controls="mobile-menu"
+        >
+          {open ? (
+            <X className="h-5 w-5 text-slate-900 dark:text-zinc-100" />
+          ) : (
+            <Menu className="h-5 w-5 text-slate-900 dark:text-zinc-100" />
+          )}
+        </button>
+      </div>
+
+      {/* Mobile menu */}
+      {open && (
+        <div
+          id="mobile-menu"
+          className="border-t border-slate-200 bg-white px-4 py-4 dark:border-zinc-800 dark:bg-zinc-950 md:hidden"
+        >
+          <nav className="flex flex-col gap-3" aria-label="Mobilní navigace">
+            {NAV_LINKS.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                onClick={() => setOpen(false)}
+                className={`text-sm font-medium ${
+                  pathname.startsWith(href)
+                    ? 'text-blue-600 dark:text-blue-500'
+                    : 'text-slate-600 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-zinc-100'
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+          <div className="mt-4 border-t border-slate-200 pt-4 dark:border-zinc-800">
+            {user ? (
+              <div className="flex items-center justify-between gap-4">
+                <span className="min-w-0 truncate text-xs text-slate-500 dark:text-zinc-500">
+                  {user.email}
+                </span>
+                <form action={logout}>
+                  <button
+                    type="submit"
+                    className="flex-shrink-0 rounded-md bg-slate-100 px-3 py-1 text-xs font-medium text-slate-900 hover:bg-slate-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700"
+                  >
+                    Odhlásit se
+                  </button>
+                </form>
+              </div>
+            ) : (
+              <Link
+                href="/login"
+                onClick={() => setOpen(false)}
+                className="text-sm font-medium text-blue-600 dark:text-blue-500"
+              >
+                Přihlásit se
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

- **Civic-platform color system** (`globals.css`): CSS custom properties for `--primary` (blue-600/blue-500), `--surface`, `--border`, `--background` with automatic dark mode via `@media (prefers-color-scheme: dark)`
- **Shared `<Header>` component** (`src/components/Header.tsx` + `HeaderClient.tsx`): server component reads Supabase session; client component renders logo "Náš stát", nav (Mapa / Témata / Dashboard) with active-state highlighting via `usePathname`, auth buttons, and mobile hamburger menu with `aria-expanded`
- **Root layout** now includes `<Header />` — appears on every page
- **Per-page duplicate headers removed** from reports, topics, dashboard, admin pages; heights adjusted to `calc(100vh - 4rem)` to account for the sticky 64px global Header
- **Home page** simplified — auth UI removed (now in Header), hero layout updated with new color tokens

## Test plan

- [x] 9 new Header tests: logo, nav links, login/logout display, hamburger toggle, mobile nav, active class
- [x] Updated page.test.tsx and page_auth.test.tsx (removed stale auth assertions)
- [x] Updated reports/page.test.tsx, topics/page.test.tsx (removed removed-header assertions)
- [x] `npm run test` — 222/222 passed
- [x] `npm run build` — compiled successfully, all 10 routes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)