### PR TITLE
feat: redesign Reports page — pill filters, FAB, improved form

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,37 @@
 # Developer Log
 
+## 2026-03-03 - feat: redesign reports page (Issue #39) — Oompa Loompa
+
+### Changes
+
+- **`src/app/reports/ReportsClient.tsx`**:
+  - Replaced `<select>` filter elements with pill/chip button groups.
+    - Status group: `role="group"` + `aria-label="Filtrovat podle stavu"` + `data-testid="status-filter"`. Each pill has `aria-pressed` reflecting active state.
+    - Category group: `role="group"` + `aria-label="Filtrovat podle kategorie"` + `data-testid="category-filter"`. Includes "Vše" pill for clearing the filter.
+    - Active pill: `bg-blue-600 text-white`; inactive: `bg-zinc-100 text-zinc-700`.
+  - Replaced bottom-center pill "Nahlásit podnět" button with a proper FAB.
+    - Position: `absolute bottom-6 right-6`.
+    - Shape: 56×56px circle (`h-14 w-14 rounded-full`).
+    - Color: blue-600, hover scale-105 + bg-blue-700. `aria-label="Nahlásit podnět"`.
+    - Content: `<Plus>` icon from lucide-react.
+  - Removed unused `handleStatusChange` / `handleCategoryChange` callbacks.
+  - Added `Plus` to lucide-react imports.
+- **`src/app/reports/ReportForm.tsx`**:
+  - Rounded inputs/select/textarea from `rounded-md` to `rounded-lg`.
+  - Added `py-2.5` and `focus:ring-2 focus:ring-blue-500/20` to all form controls.
+  - Submit button color changed from zinc-900 to blue-600 (consistent with civic color system).
+  - Added `overflow-y-auto` to sidebar container.
+
+### Tests
+
+- **`src/app/reports/ReportsClient.test.tsx`** (29 tests, all pass):
+  - Added `within` import from `@testing-library/react`.
+  - Added `Plus` to lucide-react mock.
+  - Updated filter tests: replaced `<select>`/`fireEvent.change` pattern with `data-testid` + `within` + `fireEvent.click` on pill buttons.
+  - New tests: active pill has `aria-pressed="true"`, inactive pill has `aria-pressed="false"`, "Vše" clears category filter.
+  - All existing map/form/pagination tests unchanged and passing.
+- Full suite: **226/226 tests pass**.
+
 ## 2026-03-02 - feat: redesign landing page (Issue #38) — Oompa Loompa
 
 ### Changes

--- a/PLAN.md
+++ b/PLAN.md
@@ -123,6 +123,17 @@ Tento dokument slouží jako detailní architektonický plán pro vývojový tý
 
 _(Detailní plánování bude následovat po dokončení Fáze 2)_
 
+### Epic 3.1: Reports page redesign
+
+- [x] **Story 3.1.1: Redesign Reports page UI (Issue #39)**
+  - [x] Header.tsx already in layout — no inline header to replace
+  - [x] Filter bar: replaced `<select>` elements with pill/chip button groups
+  - [x] FAB (floating action button): 56×56px circle at bottom-right, blue-600, Plus icon
+  - [x] ReportForm sidebar: rounded-lg inputs, blue focus ring, blue submit button
+  - [x] Updated tests: 29 tests in `ReportsClient.test.tsx` (226 total pass)
+
+---
+
 ## Hotfixes / Perf Issues
 
 - [x] **Issue #22: Consolidate double reports fetch in dashboard page**

--- a/src/app/reports/ReportForm.tsx
+++ b/src/app/reports/ReportForm.tsx
@@ -23,7 +23,7 @@ export default function ReportForm({
   hasLocation,
 }: ReportFormProps) {
   return (
-    <div className="absolute inset-y-0 right-0 w-full max-w-md bg-white p-6 shadow-2xl dark:bg-zinc-900 sm:m-4 sm:rounded-2xl sm:inset-y-auto sm:top-4 sm:bottom-4">
+    <div className="absolute inset-y-0 right-0 w-full max-w-md bg-white p-6 shadow-2xl dark:bg-zinc-900 sm:m-4 sm:rounded-2xl sm:inset-y-auto sm:top-4 sm:bottom-4 overflow-y-auto">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
           Nový podnět
@@ -74,7 +74,7 @@ export default function ReportForm({
             id="title"
             name="title"
             required
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800"
             placeholder="Např. Rozbitý chodník"
           />
         </div>
@@ -89,7 +89,7 @@ export default function ReportForm({
           <select
             id="category"
             name="category"
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800"
           >
             {categories.map((cat) => (
               <option key={cat} value={cat}>
@@ -132,7 +132,7 @@ export default function ReportForm({
             id="description"
             name="description"
             rows={4}
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-700 dark:bg-zinc-800"
             placeholder="Popište podrobněji, o co jde..."
           />
         </div>
@@ -141,7 +141,7 @@ export default function ReportForm({
           <button
             type="submit"
             disabled={isSubmitting}
-            className="w-full rounded-full bg-zinc-900 py-3 font-bold text-white transition-colors hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            className="w-full rounded-full bg-blue-600 py-3 font-bold text-white transition-colors hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-400"
           >
             {isSubmitting ? 'Ukládám...' : 'Odeslat hlášení'}
           </button>

--- a/src/app/reports/ReportsClient.test.tsx
+++ b/src/app/reports/ReportsClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import ReportsClient from './ReportsClient';
 import { expect, test, vi, beforeEach, describe } from 'vitest';
 import { User } from '@supabase/supabase-js';
@@ -25,6 +25,7 @@ vi.mock('lucide-react', () => ({
   MapPin: () => <div data-testid="map-pin-icon">MapPin</div>,
   ChevronLeft: () => <span data-testid="chevron-left-icon">Prev</span>,
   ChevronRight: () => <span data-testid="chevron-right-icon">Next</span>,
+  Plus: () => <span data-testid="plus-icon">+</span>,
 }));
 
 // Mock next/navigation
@@ -179,26 +180,35 @@ describe('ReportsClient', () => {
 
   // --- Filter tests ---
 
-  test('renders filter bar with status and category selects', () => {
+  test('renders filter bar with status and category pill groups', () => {
     render(<ReportsClient {...DEFAULT_PROPS} />);
     expect(screen.getByTestId('filter-bar')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Filtrovat podle stavu/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Filtrovat podle kategorie/i)).toBeInTheDocument();
+    expect(screen.getByTestId('status-filter')).toBeInTheDocument();
+    expect(screen.getByTestId('category-filter')).toBeInTheDocument();
   });
 
-  test('status select reflects currentStatus prop', () => {
+  test('active status pill has aria-pressed true', () => {
     render(<ReportsClient {...DEFAULT_PROPS} currentStatus="pending" />);
-    const select = screen.getByLabelText(/Filtrovat podle stavu/i) as HTMLSelectElement;
-    expect(select.value).toBe('pending');
+    const statusGroup = screen.getByTestId('status-filter');
+    const pendingBtn = within(statusGroup).getByText('Čeká');
+    expect(pendingBtn).toHaveAttribute('aria-pressed', 'true');
   });
 
-  test('category select reflects currentCategory prop', () => {
+  test('inactive status pills have aria-pressed false', () => {
+    render(<ReportsClient {...DEFAULT_PROPS} currentStatus="pending" />);
+    const statusGroup = screen.getByTestId('status-filter');
+    const allBtn = within(statusGroup).getByText('Všechny stavy');
+    expect(allBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('active category pill has aria-pressed true', () => {
     render(<ReportsClient {...DEFAULT_PROPS} currentCategory="Doprava" />);
-    const select = screen.getByLabelText(/Filtrovat podle kategorie/i) as HTMLSelectElement;
-    expect(select.value).toBe('Doprava');
+    const categoryGroup = screen.getByTestId('category-filter');
+    const dopravaBtn = within(categoryGroup).getByText('Doprava');
+    expect(dopravaBtn).toHaveAttribute('aria-pressed', 'true');
   });
 
-  test('changing status navigates to filtered URL with page reset', () => {
+  test('clicking status pill navigates to filtered URL with page reset', () => {
     render(
       <ReportsClient
         {...DEFAULT_PROPS}
@@ -207,12 +217,12 @@ describe('ReportsClient', () => {
         currentCategory="Doprava"
       />
     );
-    const select = screen.getByLabelText(/Filtrovat podle stavu/i);
-    fireEvent.change(select, { target: { value: 'resolved' } });
+    const statusGroup = screen.getByTestId('status-filter');
+    fireEvent.click(within(statusGroup).getByText('Vyřešeno'));
     expect(mockPush).toHaveBeenCalledWith('/reports?status=resolved&category=Doprava');
   });
 
-  test('changing category navigates to filtered URL with page reset', () => {
+  test('clicking category pill navigates to filtered URL with page reset', () => {
     render(
       <ReportsClient
         {...DEFAULT_PROPS}
@@ -221,15 +231,22 @@ describe('ReportsClient', () => {
         currentCategory=""
       />
     );
-    const select = screen.getByLabelText(/Filtrovat podle kategorie/i);
-    fireEvent.change(select, { target: { value: 'Zeleň' } });
+    const categoryGroup = screen.getByTestId('category-filter');
+    fireEvent.click(within(categoryGroup).getByText('Zeleň'));
     expect(mockPush).toHaveBeenCalledWith('/reports?status=pending&category=Zele%C5%88');
   });
 
-  test('clearing status filter navigates without status param', () => {
+  test('clicking "Všechny stavy" pill clears status filter', () => {
     render(<ReportsClient {...DEFAULT_PROPS} currentStatus="pending" />);
-    const select = screen.getByLabelText(/Filtrovat podle stavu/i);
-    fireEvent.change(select, { target: { value: '' } });
+    const statusGroup = screen.getByTestId('status-filter');
+    fireEvent.click(within(statusGroup).getByText('Všechny stavy'));
+    expect(mockPush).toHaveBeenCalledWith('/reports');
+  });
+
+  test('clicking "Vše" category pill clears category filter', () => {
+    render(<ReportsClient {...DEFAULT_PROPS} currentCategory="Doprava" />);
+    const categoryGroup = screen.getByTestId('category-filter');
+    fireEvent.click(within(categoryGroup).getByText('Vše'));
     expect(mockPush).toHaveBeenCalledWith('/reports');
   });
 

--- a/src/app/reports/ReportsClient.tsx
+++ b/src/app/reports/ReportsClient.tsx
@@ -6,7 +6,7 @@ import { createReport } from './actions';
 import { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 import ReportForm from './ReportForm';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
 import { STATUS_LABELS } from '@/lib/reportStatus';
 
 interface ReportsClientProps {
@@ -109,20 +109,6 @@ export default function ReportsClient({
     [currentPage, currentStatus, currentCategory]
   );
 
-  const handleStatusChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      router.push(buildUrl({ status: e.target.value, page: 1 }));
-    },
-    [router, buildUrl]
-  );
-
-  const handleCategoryChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      router.push(buildUrl({ category: e.target.value, page: 1 }));
-    },
-    [router, buildUrl]
-  );
-
   const handlePrevPage = useCallback(() => {
     if (currentPage > 1) router.push(buildUrl({ page: currentPage - 1 }));
   }, [router, buildUrl, currentPage]);
@@ -142,34 +128,65 @@ export default function ReportsClient({
       {/* Filter bar */}
       <div
         data-testid="filter-bar"
-        className="absolute left-1/2 top-4 z-10 flex -translate-x-1/2 items-center gap-2 rounded-lg bg-white px-4 py-2 shadow-lg dark:bg-zinc-900"
+        className="absolute left-1/2 top-4 z-10 flex -translate-x-1/2 flex-col gap-2 rounded-xl bg-white p-3 shadow-lg dark:bg-zinc-900"
       >
-        <select
+        <div
+          data-testid="status-filter"
+          role="group"
           aria-label="Filtrovat podle stavu"
-          value={currentStatus}
-          onChange={handleStatusChange}
-          className="rounded border border-zinc-200 bg-white px-2 py-1 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          className="flex flex-wrap gap-1.5"
         >
           {STATUS_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => router.push(buildUrl({ status: opt.value, page: 1 }))}
+              aria-pressed={currentStatus === opt.value}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                currentStatus === opt.value
+                  ? 'bg-blue-600 text-white dark:bg-blue-500'
+                  : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+              }`}
+            >
               {opt.label}
-            </option>
+            </button>
           ))}
-        </select>
+        </div>
 
-        <select
+        <div
+          data-testid="category-filter"
+          role="group"
           aria-label="Filtrovat podle kategorie"
-          value={currentCategory}
-          onChange={handleCategoryChange}
-          className="rounded border border-zinc-200 bg-white px-2 py-1 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          className="flex flex-wrap gap-1.5"
         >
-          <option value="">Všechny kategorie</option>
+          <button
+            type="button"
+            onClick={() => router.push(buildUrl({ category: '', page: 1 }))}
+            aria-pressed={currentCategory === ''}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              currentCategory === ''
+                ? 'bg-blue-600 text-white dark:bg-blue-500'
+                : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+            }`}
+          >
+            Vše
+          </button>
           {CATEGORIES.map((cat) => (
-            <option key={cat} value={cat}>
+            <button
+              key={cat}
+              type="button"
+              onClick={() => router.push(buildUrl({ category: cat, page: 1 }))}
+              aria-pressed={currentCategory === cat}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                currentCategory === cat
+                  ? 'bg-blue-600 text-white dark:bg-blue-500'
+                  : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+              }`}
+            >
               {cat}
-            </option>
+            </button>
           ))}
-        </select>
+        </div>
       </div>
 
       {/* Pagination bar */}
@@ -215,14 +232,15 @@ export default function ReportsClient({
         </div>
       )}
 
-      {/* Floating button for logged-in users when form is closed */}
+      {/* FAB for logged-in users when form is closed */}
       {user && !showForm && (
         <button
           data-testid="report-without-location-btn"
           onClick={openFormWithoutLocation}
-          className={`absolute left-1/2 -translate-x-1/2 rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-bold text-white shadow-lg transition-colors hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 ${totalPages > 1 ? 'bottom-20' : 'bottom-6'}`}
+          aria-label="Nahlásit podnět"
+          className="absolute bottom-6 right-6 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-xl transition-all hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
         >
-          Nahlásit podnět
+          <Plus className="h-6 w-6" />
         </button>
       )}
 


### PR DESCRIPTION
## Summary

- Replace `<select>` status/category filter dropdowns with **pill/chip button groups** (`aria-pressed`, `data-testid`, blue active state)
- Replace the bottom-center "Nahlásit podnět" pill button with a proper **FAB** (56×56px circle, `bottom-6 right-6`, blue-600, `Plus` icon, hover scale)
- **ReportForm** improvements: `rounded-lg` inputs, `focus:ring-2 focus:ring-blue-500/20`, blue submit button (aligns with civic color system from #37)
- Header already in `layout.tsx` — no inline header changes needed

Closes #39

## Test plan

- [x] `ReportsClient.test.tsx` — 29 tests updated: `within()` helpers, click-based filter tests, `aria-pressed` assertions, `Plus` icon mock
- [x] Full suite: **226/226 tests pass**
- [ ] Manual: verify pill active states, FAB opens form, form styling on mobile and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)