### PR TITLE
feat: redesign Topics page — pill voting, FAB, improved cards

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,37 @@
 # Developer Log
 
+## 2026-03-03 - feat: redesign topics page (Issue #40) — Oompa Loompa
+
+### Changes
+
+- **`src/app/topics/page.tsx`**:
+  - Added `<h1 className="mb-6 text-2xl font-bold ...">Aktuální témata</h1>` as page-level heading.
+  - Added `pb-24` to main to give FAB clearance.
+
+- **`src/app/topics/TopicsClient.tsx`**:
+  - Removed inline "Action Header" section (inline `<h2>` + "Nové téma" button). Title moved to `page.tsx`.
+  - Voting buttons: `rounded-md px-2 py-1` → `rounded-full px-3 py-1.5` (pill style).
+  - Comment button: now pill-style (`rounded-full`) with `ml-auto` for right alignment.
+  - Comment input: `rounded-md` → `rounded-full`.
+  - Comment send button: `rounded-md` → blue `rounded-full` (matching FAB style).
+  - Cards: added `transition-shadow hover:shadow-md` for depth on hover.
+  - Added FAB: `fixed bottom-6 right-6 z-20 h-14 w-14 rounded-full bg-blue-600`, `data-testid="new-topic-fab"`, `aria-label="Nové téma"`. Hides when form is open.
+  - Added floating login CTA: `fixed bottom-6 left-1/2 -translate-x-1/2 z-20`, `data-testid="login-cta"`. Only shown for logged-out users.
+
+- **`src/app/topics/TopicsClient.test.tsx`**:
+  - Replaced 2 outdated tests (`shows login message`, `shows creation button`) with 5 new focused tests:
+    - `shows floating login CTA if not logged in`
+    - `shows FAB for logged-in user`
+    - `does not show FAB for logged-out user`
+    - `does not show login CTA for logged-in user`
+    - `FAB opens topic form modal`
+  - Updated `submits a new topic` → `submits a new topic via FAB` (clicks `data-testid="new-topic-fab"`).
+  - Added 3 style assertion tests: pill voting, card shadow/transition, pill comment input.
+  - Total: 19 tests (up from 11). All 233 project tests pass.
+
+- **`src/app/topics/page.test.tsx`**:
+  - Added assertion for `<h1>Aktuální témata</h1>` heading.
+
 ## 2026-03-03 - feat: redesign reports page (Issue #39) — Oompa Loompa
 
 ### Changes

--- a/PLAN.md
+++ b/PLAN.md
@@ -126,6 +126,14 @@ _(Detailní plánování bude následovat po dokončení Fáze 2)_
 ### Epic 3.1: Reports page redesign
 
 - [x] **Story 3.1.1: Redesign Reports page UI (Issue #39)**
+- [x] **Story 3.1.2: Redesign Topics page UI (Issue #40)**
+  - [x] Header.tsx already in layout — page title moved to `page.tsx` as `<h1>`
+  - [x] Cards: `shadow-sm hover:shadow-md transition-shadow` for hover depth
+  - [x] Voting: pill-style buttons (`rounded-full px-3 py-1.5`)
+  - [x] FAB: 56×56px circle, bottom-right, blue-600, Plus icon (`data-testid="new-topic-fab"`)
+  - [x] Login CTA: fixed floating banner for logged-out users (`data-testid="login-cta"`)
+  - [x] Comment input: pill-style (`rounded-full`)
+  - [x] Updated tests: 19 tests in `TopicsClient.test.tsx` (233 total pass)
   - [x] Header.tsx already in layout — no inline header to replace
   - [x] Filter bar: replaced `<select>` elements with pill/chip button groups
   - [x] FAB (floating action button): 56×56px circle at bottom-right, blue-600, Plus icon

--- a/src/app/topics/TopicsClient.test.tsx
+++ b/src/app/topics/TopicsClient.test.tsx
@@ -59,22 +59,44 @@ describe('TopicsClient', () => {
     render(<TopicsClient initialTopics={mockTopics} user={null} />);
     expect(screen.getByText('First Topic')).toBeInTheDocument();
     expect(screen.getByText('First Description')).toBeInTheDocument();
-    expect(screen.getByText(/Pro přidání tématu se/i)).toBeInTheDocument();
   });
 
-  test('shows login message if not logged in', () => {
+  test('shows floating login CTA if not logged in', () => {
     render(<TopicsClient initialTopics={mockTopics} user={null} />);
-    expect(screen.getByText(/Pro přidání tématu se/i)).toBeInTheDocument();
+    const cta = screen.getByTestId('login-cta');
+    expect(cta).toBeInTheDocument();
+    expect(within(cta).getByText(/Pro přidání tématu se/i)).toBeInTheDocument();
+    expect(within(cta).getByRole('link', { name: /přihlaste/i })).toHaveAttribute('href', '/login');
   });
 
-  test('shows creation button if logged in', () => {
+  test('shows FAB for logged-in user', () => {
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
+    const fab = screen.getByTestId('new-topic-fab');
+    expect(fab).toBeInTheDocument();
+    expect(fab).toHaveAttribute('aria-label', 'Nové téma');
+  });
+
+  test('does not show FAB for logged-out user', () => {
+    render(<TopicsClient initialTopics={mockTopics} user={null} />);
+    expect(screen.queryByTestId('new-topic-fab')).not.toBeInTheDocument();
+  });
+
+  test('does not show login CTA for logged-in user', () => {
+    render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
+    expect(screen.queryByTestId('login-cta')).not.toBeInTheDocument();
+  });
+
+  test('FAB opens topic form modal', () => {
+    render(<TopicsClient initialTopics={[]} user={mockUser} />);
+    fireEvent.click(screen.getByTestId('new-topic-fab'));
     expect(screen.getByText('Nové téma')).toBeInTheDocument();
+    // FAB should hide while form is open
+    expect(screen.queryByTestId('new-topic-fab')).not.toBeInTheDocument();
   });
 
   test('handles voting (logged in)', async () => {
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
-    const upButton = screen.getAllByTestId('thumb-up')[0];
+    const upButton = screen.getAllByTestId('thumb-up')[0].closest('button')!;
     fireEvent.click(upButton);
 
     await waitFor(() => {
@@ -94,11 +116,9 @@ describe('TopicsClient', () => {
 
   test('toggles comments section', () => {
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
-    const commentBtn = screen.getByTestId('message-square');
-    
-    // Comments are initially hidden? Wait, I should check the code.
-    // In my code: {commentingOn === topic.id && (...)}
-    // Initially commentingOn is null.
+    const commentBtn = screen.getByTestId('message-square').closest('button')!;
+
+    // Comments are initially hidden
     expect(screen.queryByText('Comment 1')).not.toBeInTheDocument();
 
     fireEvent.click(commentBtn);
@@ -112,10 +132,10 @@ describe('TopicsClient', () => {
   test('submits a comment and resets form', async () => {
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
     fireEvent.click(screen.getByTestId('message-square'));
-    
+
     const input = screen.getByPlaceholderText('Napište komentář...') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'New Comment', name: 'content' } });
-    
+
     const form = input.closest('form')!;
     const resetSpy = vi.spyOn(form, 'reset');
     fireEvent.submit(form);
@@ -132,7 +152,7 @@ describe('TopicsClient', () => {
     vi.mocked(voteTopic).mockRejectedValueOnce(new Error('Chyba při hlasování'));
 
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
-    const upButton = screen.getAllByTestId('thumb-up')[0];
+    const upButton = screen.getAllByTestId('thumb-up')[0].closest('button')!;
     fireEvent.click(upButton);
 
     await waitFor(() => {
@@ -140,13 +160,13 @@ describe('TopicsClient', () => {
     });
   });
 
-  test('submits a new topic', async () => {
+  test('submits a new topic via FAB', async () => {
     render(<TopicsClient initialTopics={[]} user={mockUser} />);
-    fireEvent.click(screen.getByText('Nové téma'));
-    
+    fireEvent.click(screen.getByTestId('new-topic-fab'));
+
     fireEvent.change(screen.getByLabelText(/Název tématu/i), { target: { value: 'New Topic Title', name: 'title' } });
     fireEvent.change(screen.getByLabelText(/Popis/i), { target: { value: 'New Topic Description', name: 'description' } });
-    
+
     const form = screen.getByText('Vytvořit téma').closest('form')!;
     fireEvent.submit(form);
 
@@ -159,16 +179,16 @@ describe('TopicsClient', () => {
   test('optimistically updates vote count when voting up', async () => {
     // Start with 1 upvote from user-123
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
-    
+
     // Upvote is currently 1. Clicking it should remove it (toggle).
     const upButton = screen.getAllByTestId('thumb-up')[0].closest('button')!;
     expect(within(upButton).getByText('1')).toBeInTheDocument();
-    
+
     fireEvent.click(upButton);
-    
+
     // Should immediately show 0 (optimistic)
     expect(within(upButton).getByText('0')).toBeInTheDocument();
-    
+
     await waitFor(() => {
       expect(voteTopic).toHaveBeenCalledWith('topic-1', 'up');
     });
@@ -177,15 +197,15 @@ describe('TopicsClient', () => {
   test('optimistically adds a comment to the list', async () => {
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
     fireEvent.click(screen.getByTestId('message-square'));
-    
+
     const input = screen.getByPlaceholderText('Napište komentář...') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'My Optimistic Comment', name: 'content' } });
-    
+
     fireEvent.submit(input.closest('form')!);
-    
+
     // Should immediately show the comment
     expect(screen.getByText('My Optimistic Comment')).toBeInTheDocument();
-    
+
     await waitFor(() => {
       expect(addComment).toHaveBeenCalled();
     });
@@ -194,22 +214,50 @@ describe('TopicsClient', () => {
   test('optimistically switches vote from up to down', async () => {
     // Start with 1 upvote from user-123
     render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
-    
+
     const upButton = screen.getAllByTestId('thumb-up')[0].closest('button')!;
     const downButton = screen.getAllByTestId('thumb-down')[0].closest('button')!;
-    
+
     expect(within(upButton).getByText('1')).toBeInTheDocument();
     expect(within(downButton).getByText('1')).toBeInTheDocument(); // user-456 has downvoted
-    
+
     // Switch to downvote
     fireEvent.click(downButton);
-    
+
     // Upvote should become 0, Downvote should become 2
     expect(within(upButton).getByText('0')).toBeInTheDocument();
     expect(within(downButton).getByText('2')).toBeInTheDocument();
-    
+
     await waitFor(() => {
       expect(voteTopic).toHaveBeenCalledWith('topic-1', 'down');
     });
+  });
+
+  test('voting buttons use pill style (rounded-full class)', () => {
+    render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
+    const upButton = screen.getAllByTestId('thumb-up')[0].closest('button')!;
+    const downButton = screen.getAllByTestId('thumb-down')[0].closest('button')!;
+    expect(upButton.className).toContain('rounded-full');
+    expect(downButton.className).toContain('rounded-full');
+  });
+
+  test('card has shadow and hover transition', () => {
+    render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
+    const card = screen.getByText('First Topic').closest('.rounded-xl')!;
+    expect(card.className).toContain('shadow-sm');
+    expect(card.className).toContain('transition-shadow');
+    expect(card.className).toContain('hover:shadow-md');
+  });
+
+  test('comment input uses pill style', () => {
+    render(<TopicsClient initialTopics={mockTopics} user={mockUser} />);
+    fireEvent.click(screen.getByTestId('message-square'));
+    const input = screen.getByPlaceholderText('Napište komentář...');
+    expect(input.className).toContain('rounded-full');
+  });
+
+  test('shows empty state when no topics', () => {
+    render(<TopicsClient initialTopics={[]} user={null} />);
+    expect(screen.getByText('Zatím nebyla přidána žádná témata.')).toBeInTheDocument();
   });
 });

--- a/src/app/topics/TopicsClient.tsx
+++ b/src/app/topics/TopicsClient.tsx
@@ -54,7 +54,7 @@ export default function TopicsClient({
       if (action.type === 'vote') {
         return state.map((topic) => {
           if (topic.id !== action.topicId) return topic;
-          
+
           const existingVote = topic.votes.find((v) => v.profile_id === user?.id);
           let newVotes = [...topic.votes];
 
@@ -63,7 +63,7 @@ export default function TopicsClient({
             newVotes = newVotes.filter((v) => v.profile_id !== user?.id);
           } else if (existingVote) {
             // Update vote
-            newVotes = newVotes.map((v) => 
+            newVotes = newVotes.map((v) =>
               v.profile_id === user?.id ? { ...v, vote_type: action.voteType } : v
             );
           } else if (user) {
@@ -78,7 +78,7 @@ export default function TopicsClient({
       if (action.type === 'comment') {
         return state.map((topic) => {
           if (topic.id !== action.topicId) return topic;
-          
+
           const newComment = {
             id: 'temp-id-' + Math.random(),
             content: action.content,
@@ -167,7 +167,7 @@ export default function TopicsClient({
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Error Message */}
       {error && (
         <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-red-700 dark:bg-red-900/20 dark:text-red-400">
@@ -177,30 +177,7 @@ export default function TopicsClient({
         </div>
       )}
 
-      {/* Action Header */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-          Aktuální témata
-        </h2>
-        {user ? (
-          <button
-            onClick={() => {
-              setError(null);
-              setShowForm(true);
-            }}
-            className="flex items-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-          >
-            <Plus className="h-4 w-4" />
-            Nové téma
-          </button>
-        ) : (
-          <p className="text-sm text-zinc-500">
-            Pro přidání tématu se <a href="/login" className="text-blue-600 underline">přihlaste</a>.
-          </p>
-        )}
-      </div>
-
-      {/* Creation Form Modal/Overlay */}
+      {/* Creation Form Modal */}
       {showForm && (
         <TopicForm
           onSubmit={handleCreateTopic}
@@ -227,7 +204,10 @@ export default function TopicsClient({
             const userVote = topic.votes.find(v => v.profile_id === user?.id)?.vote_type;
 
             return (
-              <div key={topic.id} className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 transition-opacity duration-200">
+              <div
+                key={topic.id}
+                className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
+              >
                 <div className="mb-2 flex items-center gap-2">
                   <span className="text-xs font-medium text-zinc-500">
                     {topic.profiles?.username || 'Anonymní uživatel'} • {new Date(topic.created_at).toLocaleDateString('cs-CZ')}
@@ -242,42 +222,49 @@ export default function TopicsClient({
                   </p>
                 )}
 
-                <div className="flex items-center gap-6 border-t border-zinc-100 pt-4 dark:border-zinc-800">
-                  <div className="flex items-center gap-2">
-                    {user ? (
-                      <>
-                        <button
-                          onClick={() => handleVote(topic.id, 'up')}
-                          disabled={isPending}
-                          className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'up' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
-                        >
-                          <ThumbsUp className={`h-4 w-4 ${userVote === 'up' ? 'fill-current' : ''}`} />
-                          <span className="text-sm font-bold">{upVotes}</span>
-                        </button>
-                        <button
-                          onClick={() => handleVote(topic.id, 'down')}
-                          disabled={isPending}
-                          className={`flex items-center gap-1 rounded-md px-2 py-1 transition-colors ${userVote === 'down' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500'}`}
-                        >
-                          <ThumbsDown className={`h-4 w-4 ${userVote === 'down' ? 'fill-current' : ''}`} />
-                          <span className="text-sm font-bold">{downVotes}</span>
-                        </button>
-                      </>
-                    ) : (
-                      <span className="flex items-center gap-3 text-sm text-zinc-400">
-                        <span className="flex items-center gap-1"><ThumbsUp className="h-4 w-4" />{upVotes}</span>
-                        <span className="flex items-center gap-1"><ThumbsDown className="h-4 w-4" />{downVotes}</span>
-                        <a href="/login" className="text-blue-600 hover:underline text-xs">Přihlaste se pro hlasování</a>
-                      </span>
-                    )}
-                  </div>
+                <div className="flex items-center gap-3 border-t border-zinc-100 pt-4 dark:border-zinc-800">
+                  {/* Voting — pill-style buttons */}
+                  {user ? (
+                    <>
+                      <button
+                        onClick={() => handleVote(topic.id, 'up')}
+                        disabled={isPending}
+                        className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+                          userVote === 'up'
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
+                        }`}
+                      >
+                        <ThumbsUp className={`h-3.5 w-3.5 ${userVote === 'up' ? 'fill-current' : ''}`} />
+                        <span className="font-bold">{upVotes}</span>
+                      </button>
+                      <button
+                        onClick={() => handleVote(topic.id, 'down')}
+                        disabled={isPending}
+                        className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+                          userVote === 'down'
+                            ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                            : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
+                        }`}
+                      >
+                        <ThumbsDown className={`h-3.5 w-3.5 ${userVote === 'down' ? 'fill-current' : ''}`} />
+                        <span className="font-bold">{downVotes}</span>
+                      </button>
+                    </>
+                  ) : (
+                    <span className="flex items-center gap-3 text-sm text-zinc-400">
+                      <span className="flex items-center gap-1"><ThumbsUp className="h-4 w-4" />{upVotes}</span>
+                      <span className="flex items-center gap-1"><ThumbsDown className="h-4 w-4" />{downVotes}</span>
+                      <a href="/login" className="text-blue-600 hover:underline text-xs">Přihlaste se pro hlasování</a>
+                    </span>
+                  )}
 
                   <button
                     onClick={() => setCommentingOn(commentingOn === topic.id ? null : topic.id)}
-                    className="flex items-center gap-1 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+                    className="ml-auto flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                   >
-                    <MessageSquare className="h-4 w-4" />
-                    <span>{topic.comments.length} komentářů</span>
+                    <MessageSquare className="h-3.5 w-3.5" />
+                    <span>{topic.comments.length}</span>
                   </button>
                 </div>
 
@@ -292,7 +279,7 @@ export default function TopicsClient({
                         <span className="text-zinc-600 dark:text-zinc-400">{comment.content}</span>
                       </div>
                     ))}
-                    
+
                     {user ? (
                       <form onSubmit={(e) => handleAddComment(e, topic.id)} className="flex gap-2">
                         <input
@@ -301,15 +288,15 @@ export default function TopicsClient({
                           placeholder="Napište komentář..."
                           required
                           disabled={isPending}
-                          className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-1 text-sm focus:border-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 disabled:opacity-50"
+                          className="flex-1 rounded-full border border-zinc-300 bg-white px-4 py-1.5 text-sm focus:border-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 disabled:opacity-50"
                         />
                         <input type="hidden" name="topic_id" value={topic.id} />
                         <button
                           type="submit"
                           disabled={isPending}
-                          className="rounded-md bg-zinc-900 px-3 py-1 text-sm text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 disabled:opacity-50"
+                          className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-400"
                         >
-                          <Send className="h-4 w-4" />
+                          <Send className="h-3.5 w-3.5" />
                         </button>
                       </form>
                     ) : (
@@ -322,7 +309,37 @@ export default function TopicsClient({
           })
         )}
       </div>
+
+      {/* Floating login CTA for logged-out users */}
+      {!user && (
+        <div
+          data-testid="login-cta"
+          className="fixed bottom-6 left-1/2 z-20 -translate-x-1/2 rounded-lg bg-white px-5 py-3 shadow-xl dark:bg-zinc-900"
+        >
+          <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            Pro přidání tématu se{' '}
+            <a href="/login" className="text-blue-600 hover:underline">
+              přihlaste
+            </a>
+            .
+          </p>
+        </div>
+      )}
+
+      {/* FAB — floating action button for logged-in users */}
+      {user && !showForm && (
+        <button
+          data-testid="new-topic-fab"
+          onClick={() => {
+            setError(null);
+            setShowForm(true);
+          }}
+          aria-label="Nové téma"
+          className="fixed bottom-6 right-6 z-20 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-xl transition-all hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
+        >
+          <Plus className="h-6 w-6" />
+        </button>
+      )}
     </div>
   );
 }
-

--- a/src/app/topics/page.test.tsx
+++ b/src/app/topics/page.test.tsx
@@ -57,6 +57,7 @@ test('renders Topics page with topics client', async () => {
   const PageComponent = await Page();
   render(PageComponent);
 
+  expect(screen.getByRole('heading', { level: 1, name: 'Aktuální témata' })).toBeInTheDocument();
   const topicsClient = screen.getByTestId('mocked-topics-client');
   expect(topicsClient).toBeInTheDocument();
   expect(screen.getByText(/Mocked TopicsClient \(1 topics\)/i)).toBeInTheDocument();

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -40,8 +40,11 @@ export default async function TopicsPage() {
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] flex-col bg-zinc-50 dark:bg-black">
-      <main className="flex-1 overflow-y-auto px-6 py-8">
+      <main className="flex-1 overflow-y-auto px-6 py-8 pb-24">
         <div className="mx-auto max-w-3xl">
+          <h1 className="mb-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            Aktuální témata
+          </h1>
           <TopicsClient initialTopics={topicsData || []} user={user} />
         </div>
       </main>


### PR DESCRIPTION
## Summary

- Moves page title `<h1>Aktuální témata</h1>` into `page.tsx` (Header.tsx already in root layout)
- Voting buttons redesigned to pill-style (`rounded-full px-3 py-1.5`) matching Reports page language
- FAB (56×56px, `bg-blue-600`, bottom-right) replaces inline "Nové téma" button; hides while modal is open
- Cards: `transition-shadow hover:shadow-md` for interactive depth
- Comment input + send button: pill-style (`rounded-full`)
- Floating login CTA (`fixed bottom-6 left-1/2`) for logged-out users instead of inline text

## Test plan

- [x] 19 `TopicsClient` tests cover: FAB visibility, login CTA, modal open/close, optimistic votes, optimistic comments, pill styles, card hover classes
- [x] `page.test.tsx` asserts `<h1>Aktuální témata</h1>` heading
- [x] All 233 project tests pass (`npm run test`)
- [ ] Manual: verify FAB opens modal, voting toggles correctly, comments post, dark mode intact

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)