### PR TITLE
feat: redesign Login page — dark mode, cleaner form (closes #42)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,33 @@
 # Developer Log
 
+## 2026-03-03 — feat: redesign Login page (Issue #42) — Oompa Loompa
+
+### Changes
+
+- **`src/app/login/page.tsx`**:
+  - Replaced `min-h-screen bg-gray-50` with `min-h-[calc(100vh-4rem)] bg-zinc-50 dark:bg-black` to account for Header height and add dark mode page background.
+  - Card: updated to `rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900` — matches dashboard/topics card style.
+  - App name: replaced `<h2>` welcome text with `<h1>Náš stát</h1>` as primary brand heading, consistent with other redesigned pages.
+  - Inputs: updated to `rounded-lg border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100` with dark focus ring.
+  - Buttons: primary uses `dark:bg-blue-500 dark:hover:bg-blue-400`; secondary uses `dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700`.
+  - Divider: `dark:border-zinc-700`, label span uses `dark:bg-zinc-900 dark:text-zinc-400`.
+  - Error/success boxes: added `data-testid` attributes and dark mode variants (`dark:bg-red-900/20`, `dark:bg-blue-900/20`).
+
+- **`src/app/login/page.test.tsx`**:
+  - Added 5 new tests: `renders app name heading`, `does not show error block when error is empty`, `does not show success block when message is empty`, `email input has correct type and autocomplete`, `password input has correct type`.
+  - Use `data-testid` selectors for error/success boxes.
+
+### Test Results
+- Login page: 9/9 tests pass (was 4, +5 new tests)
+- Full suite: 241/241 tests pass
+
+### Closes
+- Issue #42
+- Branch: `issue-42-redesign-login` → `main`
+
+---
+
+
 ## 2026-03-03 - feat: redesign Dashboard page (Issue #41) — Oompa Loompa
 
 ### Changes

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -11,11 +11,17 @@ vi.mock('./actions', () => ({
 test('renders LoginPage with form', async () => {
   const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
   render(ResolvedPage);
-  
+
   expect(screen.getByLabelText(/Emailová adresa/i)).toBeInTheDocument();
   expect(screen.getByLabelText(/Heslo/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /přihlásit se/i })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /zaregistrovat se/i })).toBeInTheDocument();
+});
+
+test('renders app name heading', async () => {
+  const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
+  render(ResolvedPage);
+  expect(screen.getByRole('heading', { name: /náš stát/i })).toBeInTheDocument();
 });
 
 test('renders Google login button', async () => {
@@ -27,11 +33,40 @@ test('renders Google login button', async () => {
 test('shows error message from searchParams', async () => {
   const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: 'Chybné údaje' }) });
   render(ResolvedPage);
+  expect(screen.getByTestId('error-message')).toBeInTheDocument();
   expect(screen.getByText(/Chybné údaje/i)).toBeInTheDocument();
 });
 
 test('shows success message from searchParams', async () => {
   const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: 'Zkontrolujte email', error: '' }) });
   render(ResolvedPage);
+  expect(screen.getByTestId('success-message')).toBeInTheDocument();
   expect(screen.getByText(/Zkontrolujte email/i)).toBeInTheDocument();
+});
+
+test('does not show error block when error is empty', async () => {
+  const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
+  render(ResolvedPage);
+  expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
+});
+
+test('does not show success block when message is empty', async () => {
+  const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
+  render(ResolvedPage);
+  expect(screen.queryByTestId('success-message')).not.toBeInTheDocument();
+});
+
+test('email input has correct type and autocomplete', async () => {
+  const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
+  render(ResolvedPage);
+  const emailInput = screen.getByLabelText(/Emailová adresa/i);
+  expect(emailInput).toHaveAttribute('type', 'email');
+  expect(emailInput).toHaveAttribute('autocomplete', 'email');
+});
+
+test('password input has correct type', async () => {
+  const ResolvedPage = await LoginPage({ searchParams: Promise.resolve({ message: '', error: '' }) });
+  render(ResolvedPage);
+  const passwordInput = screen.getByLabelText(/Heslo/i);
+  expect(passwordInput).toHaveAttribute('type', 'password');
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,21 +11,27 @@ export default async function LoginPage(props: {
 }) {
   const searchParams = await props.searchParams
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-8 bg-white p-10 rounded-xl shadow-md">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">
-            Vítejte v aplikaci Náš stát
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Přihlaste se nebo si vytvořte účet
-          </p>
-        </div>
-        
-        <div className="mt-8 space-y-6">
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-black">
+      <div className="w-full max-w-md">
+        {/* Card */}
+        <div className="rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          {/* Header */}
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+              Náš stát
+            </h1>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              Přihlaste se nebo si vytvořte účet
+            </p>
+          </div>
+
+          {/* Email/Password form */}
           <form className="space-y-4">
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="email"
+                className="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
                 Emailová adresa
               </label>
               <input
@@ -34,11 +40,16 @@ export default async function LoginPage(props: {
                 type="email"
                 autoComplete="email"
                 required
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 sm:text-sm"
+                className="block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:border-blue-400 dark:focus:ring-blue-400"
               />
             </div>
+
             <div>
-              <label htmlFor="password" title="Heslo" className="block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="password"
+                title="Heslo"
+                className="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
                 Heslo
               </label>
               <input
@@ -47,60 +58,68 @@ export default async function LoginPage(props: {
                 type="password"
                 autoComplete="current-password"
                 required
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 sm:text-sm"
+                className="block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:border-blue-400 dark:focus:ring-blue-400"
               />
             </div>
 
             {searchParams.error && (
-              <div className="rounded-md bg-red-50 p-4">
-                <p className="text-sm text-red-700">{searchParams.error}</p>
+              <div
+                className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/40 dark:bg-red-900/20"
+                data-testid="error-message"
+              >
+                <p className="text-sm text-red-700 dark:text-red-400">{searchParams.error}</p>
               </div>
             )}
 
             {searchParams.message && (
-              <div className="rounded-md bg-blue-50 p-4">
-                <p className="text-sm text-blue-700">{searchParams.message}</p>
+              <div
+                className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-900/40 dark:bg-blue-900/20"
+                data-testid="success-message"
+              >
+                <p className="text-sm text-blue-700 dark:text-blue-400">{searchParams.message}</p>
               </div>
             )}
 
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 pt-1">
               <button
                 formAction={login}
-                className="flex w-full justify-center rounded-md border border-transparent bg-blue-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="flex w-full justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-zinc-900"
               >
                 Přihlásit se
               </button>
               <button
                 formAction={signup}
-                className="flex w-full justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="flex w-full justify-center rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-sm font-medium text-zinc-700 shadow-sm transition-colors hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:focus:ring-offset-zinc-900"
               >
                 Zaregistrovat se
               </button>
             </div>
           </form>
 
-          <div className="relative mt-6">
+          {/* Divider */}
+          <div className="relative my-6">
             <div className="absolute inset-0 flex items-center" aria-hidden="true">
-              <div className="w-full border-t border-gray-300" />
+              <div className="w-full border-t border-zinc-200 dark:border-zinc-700" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="bg-white px-2 text-gray-500">Nebo pokračujte přes</span>
+              <span className="bg-white px-3 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
+                Nebo pokračujte přes
+              </span>
             </div>
           </div>
 
-          <div>
-            <form action={signInWithGoogle}>
-              <button
-                type="submit"
-                className="flex w-full items-center justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                <svg className="mr-2 h-5 w-5" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.9 3.22-1.9 4.28-1.2 1.2-3.06 2.4-6.42 2.4-4.8 0-8.94-3.9-8.94-8.7s4.14-8.7 8.94-8.7c2.46 0 4.5 1.02 6.1 2.52l2.32-2.32C18.16 1.44 15.56 0 12.48 0 5.6 0 0 5.6 0 12.48s5.6 12.48 12.48 12.48c3.7 0 6.48-1.24 8.62-3.46 2.22-2.22 2.92-5.34 2.92-7.82 0-.62-.04-1.24-.12-1.84h-11.4z" />
-                </svg>
-                Google
-              </button>
-            </form>
-          </div>
+          {/* Google OAuth */}
+          <form action={signInWithGoogle}>
+            <button
+              type="submit"
+              className="flex w-full items-center justify-center gap-2.5 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-sm font-medium text-zinc-700 shadow-sm transition-colors hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:focus:ring-offset-zinc-900"
+            >
+              <svg className="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.9 3.22-1.9 4.28-1.2 1.2-3.06 2.4-6.42 2.4-4.8 0-8.94-3.9-8.94-8.7s4.14-8.7 8.94-8.7c2.46 0 4.5 1.02 6.1 2.52l2.32-2.32C18.16 1.44 15.56 0 12.48 0 5.6 0 0 5.6 0 12.48s5.6 12.48 12.48 12.48c3.7 0 6.48-1.24 8.62-3.46 2.22-2.22 2.92-5.34 2.92-7.82 0-.62-.04-1.24-.12-1.84h-11.4z" />
+              </svg>
+              Google
+            </button>
+          </form>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Centered card with `Náš stát` app name as `<h1>` heading
- Full dark mode support (`dark:bg-zinc-900` card, `dark:bg-zinc-800` inputs, `dark:bg-blue-500` primary button, `dark:bg-zinc-800` secondary buttons, dark divider)
- Cleaner form: `rounded-2xl` card, `rounded-lg` inputs, improved label/button spacing, `gap-2.5` on Google button icon
- `data-testid` attributes on error/success message boxes

## Test plan

- [x] 9 login page tests pass (was 4, +5 new: heading, empty error/success state, input type/autocomplete)
- [x] 241/241 full suite pass
- [x] Login functionality unchanged (same server actions)
- [x] Dark mode: all elements have `dark:` variants consistent with Header/Dashboard/Topics patterns
- [x] Mobile responsive (max-w-md centered, px-4 padding)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)