### PR TITLE
feat: personalizovaný dashboard (#83)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,17 @@
 # Developer Log
 
+## 2026-03-13 — feat: Issue #83 — personalizovaný dashboard — Oompa Loompa
+
+### Changes
+
+- `src/app/dashboard/page.tsx` — Preference-aware dashboard: fetches user profile + preferences; partitions reports into "Vaše oblasti" (matching territories/categories) vs "Ostatní"; shows preferences banner with link to /settings for logged-in users with empty preferences; heatmap centered on filtered reports' centroid; generic `partitionReports<T>` helper with AND logic when both territory + category prefs set
+- `src/app/dashboard/page.test.tsx` — Updated: 16 tests (was 10); 6 new tests covering preferences banner, personalized sections, heatmap center, empty "Vaše oblasti" state, anonymous user (no banner), category preferences
+
+### Stats
+
+- 442 tests total, all pass (was 436 before #83)
+- Modified files: `page.tsx`, `page.test.tsx`
+
 ## 2026-03-11 — feat: Issue #82 — veřejný dashboard na titulní straně — Oompa Loompa
 
 ### Changes

--- a/PLAN.md
+++ b/PLAN.md
@@ -209,6 +209,12 @@ _(Detailní plánování bude následovat po dokončení Fáze 2)_
   - [x] `src/app/LandingClient.test.tsx` — 11 tests (stats, filters, map, CTAs, empty state, toggle)
   - [x] `src/app/page.test.tsx` — updated 8 tests with LandingClient mock and data-passing assertions
 
+### Epic 5.5: Personalizovaný dashboard (Issue #83)
+
+- [x] **Story 5.5.1: Preference-aware dashboard (Issue #83)**
+  - [x] `src/app/dashboard/page.tsx` — fetch user profile + preferences; partition reports into "Vaše oblasti" (matching territories + categories) vs "Ostatní"; preferences banner → /settings; heatmap centered on filtered region
+  - [x] `src/app/dashboard/page.test.tsx` — 6 new tests: banner visibility, personalized sections, heatmap center, empty state, anonymous user
+
 ### Epic 5.3: User Preferences & Onboarding
 
 - [x] **Story 5.3.1: Preferences na profilu + onboarding flow (Issue #81)**

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -21,11 +21,14 @@ vi.mock('lucide-react', () => ({
   Star: () => <div data-testid="star-icon">Star</div>,
   MapPin: () => <div data-testid="map-pin-icon">MapPin</div>,
   Info: () => <div data-testid="info-icon">Info</div>,
+  Settings: () => <div data-testid="settings-icon">Settings</div>,
 }));
 
 // Mock Map component
 vi.mock('@/components/Map', () => ({
-  default: () => <div data-testid="mock-map">Map</div>,
+  default: ({ center }: { center?: [number, number] }) => (
+    <div data-testid="mock-map" data-center={center ? center.join(',') : ''}>Map</div>
+  ),
 }));
 
 function makeReportsSelect(mockReports: unknown[]) {
@@ -42,11 +45,31 @@ function makeTopicsSelect(mockTopics: unknown[]) {
   };
 }
 
+function makeProfilesSelect(profile: unknown) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: profile, error: null }),
+      }),
+    }),
+  };
+}
+
+const mockReport = (overrides = {}) => ({
+  id: '1',
+  title: 'Díra v silnici',
+  description: null,
+  rating: 2,
+  category: 'doprava',
+  status: 'pending',
+  created_at: '2026-01-01T10:00:00Z',
+  location: { type: 'Point', coordinates: [14.4, 50.1] },
+  region_kraj: 'Jihomoravský kraj',
+  ...overrides,
+});
+
 test('renders Dashboard page with header, map and sections', async () => {
   const { createClient } = await import('@/utils/supabase/server');
-  const mockReports = [
-    { id: '1', title: 'Díra v silnici', rating: 2, category: 'Doprava', status: 'pending', created_at: '2026-01-01T10:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] } },
-  ];
   const mockTopics = [
     { id: '1', title: 'Nová reforma', comments: [{ id: '1' }], created_at: new Date().toISOString() },
   ];
@@ -55,7 +78,7 @@ test('renders Dashboard page with header, map and sections', async () => {
       getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
     },
     from: vi.fn().mockImplementation((table: string) => {
-      if (table === 'reports') return makeReportsSelect(mockReports);
+      if (table === 'reports') return makeReportsSelect([mockReport()]);
       if (table === 'topics') return makeTopicsSelect(mockTopics);
       return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
     }),
@@ -91,15 +114,15 @@ test('renders empty state when no data is available', async () => {
 
   expect(screen.getByText(/Zatím žádná hlášení/i)).toBeInTheDocument();
   expect(screen.getByText(/Zatím žádná témata/i)).toBeInTheDocument();
-  expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(2); // Total reports and Resolved count
-  expect(screen.getByText(/0.0 \/ 5/)).toBeInTheDocument(); // Avg rating
+  expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText(/0.0 \/ 5/)).toBeInTheDocument();
 });
 
 test('calculates and displays correct statistics', async () => {
   const { createClient } = await import('@/utils/supabase/server');
   const mockReports = [
-    { id: '1', title: 'R1', rating: 5, category: 'C1', created_at: '2026-01-01', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'resolved' },
-    { id: '2', title: 'R2', rating: 1, category: 'C2', created_at: '2026-01-02', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
+    mockReport({ id: '1', title: 'R1', rating: 5, category: 'C1', created_at: '2026-01-01', status: 'resolved', region_kraj: null }),
+    mockReport({ id: '2', title: 'R2', rating: 1, category: 'C2', created_at: '2026-01-02', status: 'pending', region_kraj: null }),
   ];
   vi.mocked(createClient).mockResolvedValue({
     auth: {
@@ -115,21 +138,18 @@ test('calculates and displays correct statistics', async () => {
   const PageComponent = await Page();
   render(PageComponent);
 
-  // Average of 5 and 1 is 3.0
   expect(screen.getByText(/3.0 \/ 5/)).toBeInTheDocument();
-  // Total reports = 2
   expect(screen.getByText('2')).toBeInTheDocument();
-  // Resolved count = 1
   expect(screen.getByText('1')).toBeInTheDocument();
 });
 
 test('renders Czech status labels for reports in the dashboard', async () => {
   const { createClient } = await import('@/utils/supabase/server');
   const statuses = [
-    { id: '1', title: 'R1', rating: 3, category: 'C', created_at: '2026-01-01', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '2', title: 'R2', rating: 3, category: 'C', created_at: '2026-01-02', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'in_review' },
-    { id: '3', title: 'R3', rating: 3, category: 'C', created_at: '2026-01-03', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'resolved' },
-    { id: '4', title: 'R4', rating: 3, category: 'C', created_at: '2026-01-04', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'rejected' },
+    mockReport({ id: '1', title: 'R1', rating: 3, created_at: '2026-01-01', status: 'pending', region_kraj: null }),
+    mockReport({ id: '2', title: 'R2', rating: 3, created_at: '2026-01-02', status: 'in_review', region_kraj: null }),
+    mockReport({ id: '3', title: 'R3', rating: 3, created_at: '2026-01-03', status: 'resolved', region_kraj: null }),
+    mockReport({ id: '4', title: 'R4', rating: 3, created_at: '2026-01-04', status: 'rejected', region_kraj: null }),
   ];
   vi.mocked(createClient).mockResolvedValue({
     auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
@@ -176,15 +196,14 @@ test('sorts popular topics by comment count', async () => {
 
 test('derives latest 5 reports sorted by created_at descending from single query', async () => {
   const { createClient } = await import('@/utils/supabase/server');
-  // 7 reports — only top 5 by created_at should appear in "Nejnovější hlášení"
   const mockReports = [
-    { id: '1', title: 'Old Report', rating: 3, category: 'C', created_at: '2026-01-01T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '2', title: 'Very Old Report', rating: 3, category: 'C', created_at: '2025-12-01T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '3', title: 'Newest Report', rating: 3, category: 'C', created_at: '2026-03-01T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '4', title: 'Second Report', rating: 3, category: 'C', created_at: '2026-02-20T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '5', title: 'Third Report', rating: 3, category: 'C', created_at: '2026-02-10T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '6', title: 'Fourth Report', rating: 3, category: 'C', created_at: '2026-02-05T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
-    { id: '7', title: 'Fifth Report', rating: 3, category: 'C', created_at: '2026-01-15T00:00:00Z', location: { type: 'Point', coordinates: [14.4, 50.1] }, status: 'pending' },
+    mockReport({ id: '1', title: 'Old Report', rating: 3, created_at: '2026-01-01T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '2', title: 'Very Old Report', rating: 3, created_at: '2025-12-01T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '3', title: 'Newest Report', rating: 3, created_at: '2026-03-01T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '4', title: 'Second Report', rating: 3, created_at: '2026-02-20T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '5', title: 'Third Report', rating: 3, created_at: '2026-02-10T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '6', title: 'Fourth Report', rating: 3, created_at: '2026-02-05T00:00:00Z', status: 'pending', region_kraj: null }),
+    mockReport({ id: '7', title: 'Fifth Report', rating: 3, created_at: '2026-01-15T00:00:00Z', status: 'pending', region_kraj: null }),
   ];
   vi.mocked(createClient).mockResolvedValue({
     auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
@@ -198,13 +217,11 @@ test('derives latest 5 reports sorted by created_at descending from single query
   const PageComponent = await Page();
   render(PageComponent);
 
-  // Top 5 newest: Newest Report, Second Report, Third Report, Fourth Report, Fifth Report
   expect(screen.getByText('Newest Report')).toBeInTheDocument();
   expect(screen.getByText('Second Report')).toBeInTheDocument();
   expect(screen.getByText('Third Report')).toBeInTheDocument();
   expect(screen.getByText('Fourth Report')).toBeInTheDocument();
   expect(screen.getByText('Fifth Report')).toBeInTheDocument();
-  // Old Report and Very Old Report are cut off
   expect(screen.queryByText('Old Report')).not.toBeInTheDocument();
   expect(screen.queryByText('Very Old Report')).not.toBeInTheDocument();
 });
@@ -264,7 +281,6 @@ test('renders heatmap section with card wrapper (redesign)', async () => {
   const heatmapSection = screen.getByTestId('heatmap-section');
   expect(heatmapSection).toBeInTheDocument();
   expect(heatmapSection.tagName).toBe('SECTION');
-  // Card wrapper has bg-white class
   expect(heatmapSection.className).toContain('bg-white');
 });
 
@@ -273,10 +289,11 @@ test('issues only one query to reports table per page load', async () => {
   const fromSpy = vi.fn().mockImplementation((table: string) => {
     if (table === 'reports') return makeReportsSelect([]);
     if (table === 'topics') return makeTopicsSelect([]);
+    if (table === 'profiles') return makeProfilesSelect(null);
     return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
   });
   vi.mocked(createClient).mockResolvedValue({
-    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
     from: fromSpy,
   } as unknown as ReturnType<typeof createClient>);
 
@@ -284,4 +301,149 @@ test('issues only one query to reports table per page load', async () => {
 
   const reportsCallCount = fromSpy.mock.calls.filter(([table]: [string]) => table === 'reports').length;
   expect(reportsCallCount).toBe(1);
+});
+
+test('shows preferences banner for logged-in user with no preferences', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect([]);
+      if (table === 'topics') return makeTopicsSelect([]);
+      if (table === 'profiles') return makeProfilesSelect({ preferences: {} });
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  expect(screen.getByTestId('preferences-banner')).toBeInTheDocument();
+  expect(screen.getByText(/Nastavte si preference/i)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Nastavit preference/i })).toHaveAttribute('href', '/settings');
+});
+
+test('does not show preferences banner for anonymous user', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect([]);
+      if (table === 'topics') return makeTopicsSelect([]);
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  expect(screen.queryByTestId('preferences-banner')).not.toBeInTheDocument();
+});
+
+test('shows personalized sections for logged-in user with territory preferences', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  // CZ064 = Jihomoravský kraj
+  const userPrefs = { territories: ['CZ064'], categories: [], territory_level: 'kraj' };
+  const reportsData = [
+    mockReport({ id: '1', title: 'Brno Report', region_kraj: 'Jihomoravský kraj', category: 'doprava', created_at: '2026-03-01T00:00:00Z' }),
+    mockReport({ id: '2', title: 'Praha Report', region_kraj: 'Hlavní město Praha', category: 'zelen', created_at: '2026-03-02T00:00:00Z' }),
+  ];
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect(reportsData);
+      if (table === 'topics') return makeTopicsSelect([]);
+      if (table === 'profiles') return makeProfilesSelect({ preferences: userPrefs });
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  expect(screen.getByTestId('my-reports-section')).toBeInTheDocument();
+  expect(screen.getByTestId('other-reports-section')).toBeInTheDocument();
+  expect(screen.getByText('Vaše oblasti')).toBeInTheDocument();
+  expect(screen.getByText('Ostatní hlášení')).toBeInTheDocument();
+  expect(screen.getByText('Brno Report')).toBeInTheDocument();
+  expect(screen.getByText('Praha Report')).toBeInTheDocument();
+  // Heatmap title should be personalized
+  expect(screen.getByText('Heatmapa vašich oblastí')).toBeInTheDocument();
+});
+
+test('shows personalized sections for logged-in user with category preferences', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  const userPrefs = { territories: [], categories: ['doprava'], territory_level: '' };
+  const reportsData = [
+    mockReport({ id: '1', title: 'Doprava Report', region_kraj: 'Jihomoravský kraj', category: 'doprava', created_at: '2026-03-01T00:00:00Z' }),
+    mockReport({ id: '2', title: 'Zelen Report', region_kraj: 'Jihomoravský kraj', category: 'zelen', created_at: '2026-03-02T00:00:00Z' }),
+  ];
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect(reportsData);
+      if (table === 'topics') return makeTopicsSelect([]);
+      if (table === 'profiles') return makeProfilesSelect({ preferences: userPrefs });
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  expect(screen.getByTestId('my-reports-section')).toBeInTheDocument();
+  expect(screen.getByText('Doprava Report')).toBeInTheDocument();
+  expect(screen.getByText('Zelen Report')).toBeInTheDocument();
+});
+
+test('heatmap is centered on filtered reports region', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  const userPrefs = { territories: ['CZ064'], categories: [], territory_level: 'kraj' };
+  const reportsData = [
+    mockReport({ id: '1', title: 'Brno Report', region_kraj: 'Jihomoravský kraj', category: 'doprava', created_at: '2026-03-01T00:00:00Z', location: { type: 'Point', coordinates: [16.6, 49.2] } }),
+  ];
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect(reportsData);
+      if (table === 'topics') return makeTopicsSelect([]);
+      if (table === 'profiles') return makeProfilesSelect({ preferences: userPrefs });
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  const map = screen.getByTestId('mock-map');
+  // Center should be around Brno's coordinates
+  expect(map).toHaveAttribute('data-center');
+  const center = map.getAttribute('data-center');
+  expect(center).toContain('16.6');
+  expect(center).toContain('49.2');
+});
+
+test('shows empty state in my-reports when no reports match preferences', async () => {
+  const { createClient } = await import('@/utils/supabase/server');
+  // User prefers Praha but all reports are in Brno
+  const userPrefs = { territories: ['CZ010'], categories: [], territory_level: 'kraj' };
+  const reportsData = [
+    mockReport({ id: '1', title: 'Brno Report', region_kraj: 'Jihomoravský kraj', category: 'doprava', created_at: '2026-03-01T00:00:00Z' }),
+  ];
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }) },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'reports') return makeReportsSelect(reportsData);
+      if (table === 'topics') return makeTopicsSelect([]);
+      if (table === 'profiles') return makeProfilesSelect({ preferences: userPrefs });
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) };
+    }),
+  } as unknown as ReturnType<typeof createClient>);
+
+  const PageComponent = await Page();
+  render(PageComponent);
+
+  expect(screen.getByTestId('my-reports-section')).toBeInTheDocument();
+  expect(screen.getByText(/Žádná hlášení odpovídající vašim preferencím/i)).toBeInTheDocument();
+  expect(screen.getByText('Brno Report')).toBeInTheDocument(); // in "Ostatní"
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,18 +1,85 @@
 import Link from 'next/link';
-import { Star, MapPin, MessageSquare, TrendingUp, Info } from 'lucide-react';
+import { Star, MapPin, MessageSquare, TrendingUp, Info, Settings } from 'lucide-react';
 import { createClient } from '@/utils/supabase/server';
 import Map, { Report } from '@/components/Map';
 import { STATUS_LABELS, STATUS_COLORS } from '@/lib/reportStatus';
 import { parseLocation } from '@/utils/geo';
+import { KRAJE } from '@/lib/territories';
+
+interface Preferences {
+  territory_level?: string;
+  territories?: string[];
+  categories?: string[];
+}
+
+function partitionReports<T extends { region_kraj?: string | null; category?: string | null }>(
+  reports: T[],
+  preferences: Preferences,
+): { mine: T[]; others: T[] } {
+  const preferredKrajLabels = (preferences.territories ?? [])
+    .map((code) => KRAJE.find((k) => k.code === code)?.label)
+    .filter(Boolean) as string[];
+  const preferredCategories = preferences.categories ?? [];
+
+  const hasTerr = preferredKrajLabels.length > 0;
+  const hasCat = preferredCategories.length > 0;
+
+  if (!hasTerr && !hasCat) {
+    return { mine: [], others: reports };
+  }
+
+  const mine: T[] = [];
+  const others: T[] = [];
+
+  for (const r of reports) {
+    const matchesTerr = hasTerr ? preferredKrajLabels.includes(r.region_kraj ?? '') : true;
+    const matchesCat = hasCat ? preferredCategories.includes(r.category ?? '') : true;
+    const isMatch = hasTerr && hasCat ? matchesTerr && matchesCat : matchesTerr && matchesCat;
+    if (isMatch) {
+      mine.push(r);
+    } else {
+      others.push(r);
+    }
+  }
+
+  return { mine, others };
+}
+
+function computeCenter(mapReports: Report[]): [number, number] | undefined {
+  if (mapReports.length === 0) return undefined;
+  const sumLng = mapReports.reduce((s, r) => s + r.location.lng, 0);
+  const sumLat = mapReports.reduce((s, r) => s + r.location.lat, 0);
+  return [sumLng / mapReports.length, sumLat / mapReports.length];
+}
 
 export default async function DashboardPage() {
   const supabase = await createClient();
+
+  // Get current user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Fetch profile preferences if logged in
+  let preferences: Preferences | null = null;
+  if (user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('preferences')
+      .eq('id', user.id)
+      .single();
+    preferences = (profile?.preferences as Preferences) ?? {};
+  }
+
+  const preferencesEmpty =
+    !preferences ||
+    (!(preferences.territories?.length) && !(preferences.categories?.length));
 
   // Fetch stats and latest data — single query to reports, derive latest 5 in JS
   const [reportsResponse, topicsResponse] = await Promise.all([
     supabase
       .from('reports')
-      .select('id, title, description, location, rating, category, status, created_at'),
+      .select('id, title, description, location, rating, category, status, created_at, region_kraj'),
     supabase
       .from('topics')
       .select('*, comments(id)')
@@ -23,34 +90,61 @@ export default async function DashboardPage() {
   const latestReports = [...allReportsData]
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
     .slice(0, 5);
-  
+
   // Sort topics by popularity (comment count)
   const popularTopics = (topicsResponse.data || [])
     .sort((a, b) => (b.comments?.length || 0) - (a.comments?.length || 0))
     .slice(0, 5);
 
   const totalReports = allReportsData.length;
-  const avgRating = totalReports > 0 
-    ? (allReportsData.reduce((acc, curr) => acc + (curr.rating || 0), 0) / totalReports).toFixed(1)
-    : '0.0';
-  
-  const resolvedCount = allReportsData.filter(r => r.status === 'resolved').length;
+  const avgRating =
+    totalReports > 0
+      ? (allReportsData.reduce((acc, curr) => acc + (curr.rating || 0), 0) / totalReports).toFixed(1)
+      : '0.0';
+
+  const resolvedCount = allReportsData.filter((r) => r.status === 'resolved').length;
 
   // Format reports for the map; skip reports without location
-  const mapReports: Report[] = allReportsData
-    .flatMap(r => {
-      const loc = parseLocation(r.location);
-      if (!loc) return [];
-      return [{
-        id: r.id,
-        title: r.title,
-        description: r.description,
-        rating: r.rating,
-        category: r.category,
-        status: r.status,
-        location: loc
-      }];
-    });
+  const toMapReport = (r: (typeof allReportsData)[number]): Report | null => {
+    const loc = parseLocation(r.location);
+    if (!loc) return null;
+    return {
+      id: r.id,
+      title: r.title,
+      description: r.description,
+      rating: r.rating,
+      category: r.category,
+      status: r.status,
+      location: loc,
+    };
+  };
+
+  const allMapReports: Report[] = allReportsData.flatMap((r) => {
+    const mapped = toMapReport(r);
+    return mapped ? [mapped] : [];
+  });
+
+  // Partition by preferences (only when user is logged in and has prefs)
+  const { mine: myReportsData, others: otherReportsData } =
+    user && preferences && !preferencesEmpty
+      ? partitionReports(allReportsData, preferences)
+      : { mine: [], others: allReportsData };
+
+  const myMapReports: Report[] = myReportsData.flatMap((r) => {
+    const mapped = toMapReport(r);
+    return mapped ? [mapped] : [];
+  });
+
+  // Center heatmap on preferred area if possible
+  const heatmapCenter = myMapReports.length > 0 ? computeCenter(myMapReports) : undefined;
+  const heatmapReports = user && !preferencesEmpty ? myMapReports : allMapReports;
+
+  const myLatestReports = [...myReportsData]
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+    .slice(0, 5);
+  const otherLatestReports = [...otherReportsData]
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+    .slice(0, 5);
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] flex-col bg-zinc-50 dark:bg-black">
@@ -60,7 +154,28 @@ export default async function DashboardPage() {
             Pulse Dashboard
           </h1>
           <div className="space-y-8">
-          
+
+          {/* Preferences banner — shown for logged-in users with empty preferences */}
+          {user && preferencesEmpty && (
+            <div
+              data-testid="preferences-banner"
+              className="flex items-center justify-between rounded-xl border border-blue-200 bg-blue-50 px-6 py-4 dark:border-blue-900 dark:bg-blue-950/30"
+            >
+              <div className="flex items-center gap-3">
+                <Settings className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                <span className="text-sm text-blue-800 dark:text-blue-200">
+                  Nastavte si preference, abyste viděli hlášení z vašeho regionu.
+                </span>
+              </div>
+              <Link
+                href="/settings"
+                className="ml-4 shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Nastavit preference
+              </Link>
+            </div>
+          )}
+
           {/* Stats Grid */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div
@@ -129,17 +244,73 @@ export default async function DashboardPage() {
           >
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                Geografický pulz (Heatmapa)
+                {user && !preferencesEmpty ? 'Heatmapa vašich oblastí' : 'Geografický pulz (Heatmapa)'}
               </h2>
               <span className="text-xs text-zinc-500">Intenzita hlášení podle lokality a hodnocení</span>
             </div>
             <div className="h-80 overflow-hidden rounded-xl border border-zinc-100 dark:border-zinc-800">
-              <Map reports={mapReports} readOnly zoom={10} showHeatmap />
+              <Map
+                reports={heatmapReports}
+                readOnly
+                zoom={heatmapCenter ? 9 : 10}
+                center={heatmapCenter}
+                showHeatmap
+              />
             </div>
           </section>
 
-          <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-            {/* Latest Reports Section */}
+          {/* Personalized sections for logged-in users with preferences */}
+          {user && !preferencesEmpty ? (
+            <>
+              {/* "Vaše oblasti" section */}
+              <section data-testid="my-reports-section" className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                    Vaše oblasti
+                  </h2>
+                  <Link href="/reports" className="text-xs font-medium text-blue-600 hover:underline">
+                    Zobrazit vše
+                  </Link>
+                </div>
+                <div className="divide-y divide-zinc-200 rounded-xl border border-zinc-200 bg-white shadow-sm dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+                  {myLatestReports.length === 0 ? (
+                    <div className="p-6 text-center text-sm text-zinc-500">
+                      Žádná hlášení odpovídající vašim preferencím.{' '}
+                      <Link href="/settings" className="text-blue-600 hover:underline">
+                        Upravit preference
+                      </Link>
+                    </div>
+                  ) : (
+                    myLatestReports.map((report) => (
+                      <ReportRow key={report.id} report={report} />
+                    ))
+                  )}
+                </div>
+              </section>
+
+              {/* "Ostatní" section */}
+              <section data-testid="other-reports-section" className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                    Ostatní hlášení
+                  </h2>
+                  <Link href="/reports" className="text-xs font-medium text-blue-600 hover:underline">
+                    Zobrazit vše
+                  </Link>
+                </div>
+                <div className="divide-y divide-zinc-200 rounded-xl border border-zinc-200 bg-white shadow-sm dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+                  {otherLatestReports.length === 0 ? (
+                    <div className="p-6 text-center text-sm text-zinc-500">Žádná ostatní hlášení.</div>
+                  ) : (
+                    otherLatestReports.map((report) => (
+                      <ReportRow key={report.id} report={report} />
+                    ))
+                  )}
+                </div>
+              </section>
+            </>
+          ) : (
+            /* Default non-personalized section */
             <section className="space-y-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
@@ -154,71 +325,78 @@ export default async function DashboardPage() {
                   <div className="p-6 text-center text-sm text-zinc-500">Zatím žádná hlášení.</div>
                 ) : (
                   latestReports.map((report) => (
-                    <div key={report.id} className="p-4 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {report.title}
-                        </span>
-                        <div className="flex items-center gap-1">
-                          {[...Array(5)].map((_, i) => (
-                            <Star
-                              key={i}
-                              className={`h-3 w-3 ${
-                                i < report.rating ? 'fill-yellow-500 text-yellow-500' : 'text-zinc-300 dark:text-zinc-700'
-                              }`}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                      <div className="mt-1 flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
-                        <span>{report.category}</span>
-                        <span className={`rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider ${STATUS_COLORS[report.status] ?? STATUS_COLORS.pending}`}>
-                          {STATUS_LABELS[report.status] ?? STATUS_LABELS.pending}
-                        </span>
-                      </div>
-                    </div>
+                    <ReportRow key={report.id} report={report} />
                   ))
                 )}
               </div>
             </section>
+          )}
 
-            {/* Popular Topics Section */}
-            <section className="space-y-4">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                  Populární témata
-                </h2>
-                <Link href="/topics" className="text-xs font-medium text-blue-600 hover:underline">
-                  Zobrazit feed
-                </Link>
-              </div>
-              <div className="divide-y divide-zinc-200 rounded-xl border border-zinc-200 bg-white shadow-sm dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
-                {popularTopics.length === 0 ? (
-                  <div className="p-6 text-center text-sm text-zinc-500">Zatím žádná témata.</div>
-                ) : (
-                  popularTopics.map((topic) => (
-                    <div key={topic.id} className="p-4 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100 line-clamp-1">
-                          {topic.title}
-                        </span>
-                        <div className="flex items-center gap-1 text-xs text-zinc-500">
-                          <MessageSquare className="h-3 w-3" />
-                          {topic.comments?.length || 0}
-                        </div>
-                      </div>
-                      <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                        Založeno: {new Date(topic.created_at).toLocaleDateString('cs-CZ')}
+          {/* Popular Topics Section */}
+          <section className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                Populární témata
+              </h2>
+              <Link href="/topics" className="text-xs font-medium text-blue-600 hover:underline">
+                Zobrazit feed
+              </Link>
+            </div>
+            <div className="divide-y divide-zinc-200 rounded-xl border border-zinc-200 bg-white shadow-sm dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+              {popularTopics.length === 0 ? (
+                <div className="p-6 text-center text-sm text-zinc-500">Zatím žádná témata.</div>
+              ) : (
+                popularTopics.map((topic) => (
+                  <div key={topic.id} className="p-4 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-zinc-900 dark:text-zinc-100 line-clamp-1">
+                        {topic.title}
+                      </span>
+                      <div className="flex items-center gap-1 text-xs text-zinc-500">
+                        <MessageSquare className="h-3 w-3" />
+                        {topic.comments?.length || 0}
                       </div>
                     </div>
-                  ))
-                )}
-              </div>
-            </section>
-          </div>
+                    <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                      Založeno: {new Date(topic.created_at).toLocaleDateString('cs-CZ')}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
           </div>
         </div>
       </main>
+    </div>
+  );
+}
+
+function ReportRow({ report }: { report: { id: string; title: string; rating: number; category: string | null; status: string; created_at: string } }) {
+  return (
+    <div className="p-4 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-zinc-900 dark:text-zinc-100">
+          {report.title}
+        </span>
+        <div className="flex items-center gap-1">
+          {[...Array(5)].map((_, i) => (
+            <Star
+              key={i}
+              className={`h-3 w-3 ${
+                i < report.rating ? 'fill-yellow-500 text-yellow-500' : 'text-zinc-300 dark:text-zinc-700'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="mt-1 flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
+        <span>{report.category}</span>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider ${STATUS_COLORS[report.status] ?? STATUS_COLORS.pending}`}>
+          {STATUS_LABELS[report.status] ?? STATUS_LABELS.pending}
+        </span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Partition reports into **Vaše oblasti** (user's preferred territories + categories) vs **Ostatní hlášení** based on profile preferences
- Show a preferences banner (→ `/settings`) for logged-in users with empty preferences
- Center heatmap on centroid of filtered reports when preferences are set; fall back to default Prague center otherwise
- Anonymous users and users without preferences see the original "Nejnovější hlášení" single-section layout

## Changes

- `src/app/dashboard/page.tsx` — preference-aware queries, `partitionReports<T>` generic helper, new sections, banner, centroid computation
- `src/app/dashboard/page.test.tsx` — 16 tests (was 10); 6 new: banner visibility, personalized sections, heatmap center, empty "Vaše oblasti", anonymous user, category-only preferences

## Test plan

- [x] `npx vitest run src/app/dashboard/page.test.tsx` — 16/16 pass
- [x] `npm run test` — 442/442 pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors in production files

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)